### PR TITLE
feat(profile): implement ProfileService

### DIFF
--- a/e2e/profile_test.go
+++ b/e2e/profile_test.go
@@ -1,0 +1,23 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestProfile_Get(t *testing.T) {
+	ctx := testContext(t)
+
+	p, err := testClient.Profile.Get(ctx)
+	if err != nil {
+		t.Fatalf("Profile.Get: %v", err)
+	}
+	if p.GeneralInfo == nil {
+		t.Fatal("expected generalInfo to be non-nil")
+	}
+	if p.GeneralInfo.StoreID == 0 {
+		t.Error("expected non-zero storeId")
+	}
+	if p.Settings != nil && p.Settings.StoreName == "" {
+		t.Log("storeName is empty (may be expected for test stores)")
+	}
+}

--- a/ecwid/client.go
+++ b/ecwid/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/matthiasbruns/ecwid-go/ecwid/dictionaries"
 	"github.com/matthiasbruns/ecwid-go/ecwid/domains"
 	"github.com/matthiasbruns/ecwid-go/ecwid/internal/api"
+	"github.com/matthiasbruns/ecwid-go/ecwid/profile"
 	"github.com/matthiasbruns/ecwid-go/ecwid/reports"
 	"github.com/matthiasbruns/ecwid-go/ecwid/staff"
 	"github.com/matthiasbruns/ecwid-go/ecwid/subscriptions"
@@ -30,6 +31,7 @@ type Client struct {
 	Customers     *customers.Service
 	Dictionaries  *dictionaries.Service
 	Domains       *domains.Service
+	Profile       *profile.Service
 	Reports       *reports.Service
 	Staff         *staff.Service
 	Subscriptions *subscriptions.Service
@@ -89,6 +91,7 @@ func NewClient(cfg config.Config, opts ...Option) *Client {
 		Customers:     customers.NewService(requester),
 		Dictionaries:  dictionaries.NewService(requester),
 		Domains:       domains.NewService(requester),
+		Profile:       profile.NewService(requester),
 		Reports:       reports.NewService(requester),
 		Staff:         staff.NewService(requester),
 		Subscriptions: subscriptions.NewService(requester),

--- a/ecwid/profile/service.go
+++ b/ecwid/profile/service.go
@@ -1,0 +1,41 @@
+package profile
+
+import (
+	"context"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/internal/api"
+)
+
+// Service provides access to the Ecwid store profile API.
+type Service struct {
+	requester api.Requester
+}
+
+// NewService creates a new profile service.
+func NewService(requester api.Requester) *Service {
+	return &Service{requester: requester}
+}
+
+// Get returns the full store profile.
+//
+// API: GET /profile
+// Required scope: read_store_profile
+func (s *Service) Get(ctx context.Context) (*Profile, error) {
+	var result Profile
+	if err := s.requester.Get(ctx, "/profile", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// Update modifies the store profile.
+//
+// API: PUT /profile
+// Required scope: update_store_profile
+func (s *Service) Update(ctx context.Context, req *UpdateRequest) (*UpdateResult, error) {
+	var result UpdateResult
+	if err := s.requester.Put(ctx, "/profile", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/ecwid/profile/service_test.go
+++ b/ecwid/profile/service_test.go
@@ -1,0 +1,108 @@
+package profile_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/internal/api"
+	"github.com/matthiasbruns/ecwid-go/ecwid/profile"
+)
+
+func newTestService(t *testing.T, srv *httptest.Server) *profile.Service {
+	t.Helper()
+	return profile.NewService(api.NewHTTPClient(api.HTTPClientConfig{
+		BaseURL: srv.URL + "/api/v3",
+		StoreID: "12345",
+		Token:   "secret_test",
+	}))
+}
+
+func TestGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/12345/profile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"generalInfo": {"storeId": 12345, "storeUrl": "https://store.example.com"},
+			"account": {"accountName": "Test Store", "accountEmail": "test@example.com"},
+			"settings": {"storeName": "My Store", "closed": false},
+			"company": {"companyName": "ACME Inc.", "city": "Berlin", "countryCode": "DE"}
+		}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	p, err := svc.Get(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.GeneralInfo == nil || p.GeneralInfo.StoreID != 12345 {
+		t.Error("expected storeId=12345")
+	}
+	if p.Account == nil || p.Account.AccountName != "Test Store" {
+		t.Error("expected accountName=Test Store")
+	}
+	if p.Settings == nil || p.Settings.StoreName != "My Store" {
+		t.Error("expected storeName=My Store")
+	}
+	if p.Company == nil || p.Company.CompanyName != "ACME Inc." {
+		t.Error("expected companyName=ACME Inc.")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v3/12345/profile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Error("expected Content-Type: application/json")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"updateCount":1}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.Update(context.Background(), &profile.UpdateRequest{
+		Settings: &profile.Settings{StoreName: "Updated Store"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.UpdateCount != 1 {
+		t.Errorf("expected updateCount=1, got %d", result.UpdateCount)
+	}
+}
+
+func TestGet_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errorMessage":"access denied","errorCode":"403"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	_, err := svc.Get(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *api.APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", apiErr.StatusCode)
+	}
+}

--- a/ecwid/profile/types.go
+++ b/ecwid/profile/types.go
@@ -1,0 +1,206 @@
+// Package profile provides access to the Ecwid store profile API.
+package profile
+
+import "encoding/json"
+
+// Profile represents the store profile returned by the Ecwid API.
+type Profile struct {
+	GeneralInfo            *GeneralInfo          `json:"generalInfo,omitempty"`
+	Account                *Account              `json:"account,omitempty"`
+	Settings               *Settings             `json:"settings,omitempty"`
+	MailSettings           *MailSettings         `json:"mailNotifications,omitempty"`
+	Company                *Company              `json:"company,omitempty"`
+	FormatsAndUnits        *FormatsAndUnits      `json:"formatsAndUnits,omitempty"`
+	Languages              *Languages            `json:"languages,omitempty"`
+	Shipping               *Shipping             `json:"shipping,omitempty"`
+	TaxSettings            *TaxSettings          `json:"taxSettings,omitempty"`
+	Zones                  []Zone                `json:"zones,omitempty"`
+	BusinessRegistrationID *BusinessRegistration `json:"businessRegistrationID,omitempty"`
+	LegalPagesSettings     *LegalPagesSettings   `json:"legalPagesSettings,omitempty"`
+	Payment                json.RawMessage       `json:"payment,omitempty"`
+	FeatureToggles         json.RawMessage       `json:"featureToggles,omitempty"`
+	DesignSettings         json.RawMessage       `json:"designSettings,omitempty"`
+	ProductFiltersSettings json.RawMessage       `json:"productFiltersSettings,omitempty"`
+}
+
+// GeneralInfo holds basic store information.
+type GeneralInfo struct {
+	StoreID        int64        `json:"storeId"`
+	StoreURL       string       `json:"storeUrl,omitempty"`
+	StarterSite    *StarterSite `json:"starterSite,omitempty"`
+	InstantSiteURL string       `json:"instantSiteUrl,omitempty"`
+}
+
+// StarterSite holds the Ecwid Instant Site configuration.
+type StarterSite struct {
+	EcwidSubdomain string `json:"ecwidSubdomain,omitempty"`
+	CustomDomain   string `json:"customDomain,omitempty"`
+	GeneratedURL   string `json:"generatedUrl,omitempty"`
+	StoreLogoURL   string `json:"storeLogoUrl,omitempty"`
+}
+
+// Account holds store account details.
+type Account struct {
+	AccountName       string   `json:"accountName,omitempty"`
+	AccountNickName   string   `json:"accountNickName,omitempty"`
+	AccountEmail      string   `json:"accountEmail,omitempty"`
+	AvailableFeatures []string `json:"availableFeatures,omitempty"`
+	WhiteLabel        *bool    `json:"whiteLabel,omitempty"`
+}
+
+// Settings holds general store settings.
+type Settings struct {
+	Closed                             *bool                   `json:"closed,omitempty"`
+	StoreName                          string                  `json:"storeName,omitempty"`
+	StoreDescription                   string                  `json:"storeDescription,omitempty"`
+	GoogleRemarketingEnabled           *bool                   `json:"googleRemarketingEnabled,omitempty"`
+	GoogleAnalyticsID                  string                  `json:"googleAnalyticsId,omitempty"`
+	FbPixelID                          string                  `json:"fbPixelId,omitempty"`
+	OrderCommentsEnabled               *bool                   `json:"orderCommentsEnabled,omitempty"`
+	OrderCommentsCaption               string                  `json:"orderCommentsCaption,omitempty"`
+	OrderCommentsRequired              *bool                   `json:"orderCommentsRequired,omitempty"`
+	HideOutOfStockProductsInStorefront *bool                   `json:"hideOutOfStockProductsInStorefront,omitempty"`
+	AskCompanyName                     *bool                   `json:"askCompanyName,omitempty"`
+	FavoritesEnabled                   *bool                   `json:"favoritesEnabled,omitempty"`
+	AbandonedSales                     *AbandonedSalesSettings `json:"abandonedSales,omitempty"`
+	SalePrice                          *SalePriceSettings      `json:"salePrice,omitempty"`
+}
+
+// AbandonedSalesSettings holds abandoned cart recovery settings.
+type AbandonedSalesSettings struct {
+	AutoAbandonedSalesRecovery *bool `json:"autoAbandonedSalesRecovery,omitempty"`
+}
+
+// SalePriceSettings holds sale price display settings.
+type SalePriceSettings struct {
+	DisplayOnProductList *bool  `json:"displayOnProductList,omitempty"`
+	OldPriceLabel        string `json:"oldPriceLabel,omitempty"`
+	DisplayDiscount      string `json:"displayDiscount,omitempty"`
+}
+
+// MailSettings holds mail notification settings.
+type MailSettings struct {
+	AdminNotificationEmails       []string `json:"adminNotificationEmails,omitempty"`
+	CustomerNotificationFromEmail string   `json:"customerNotificationFromEmail,omitempty"`
+}
+
+// Company holds store company information.
+type Company struct {
+	CompanyName         string `json:"companyName,omitempty"`
+	Email               string `json:"email,omitempty"`
+	Street              string `json:"street,omitempty"`
+	City                string `json:"city,omitempty"`
+	CountryCode         string `json:"countryCode,omitempty"`
+	PostalCode          string `json:"postalCode,omitempty"`
+	StateOrProvinceCode string `json:"stateOrProvinceCode,omitempty"`
+	Phone               string `json:"phone,omitempty"`
+}
+
+// FormatsAndUnits holds formatting settings.
+type FormatsAndUnits struct {
+	Currency                       string  `json:"currency,omitempty"`
+	CurrencyPrefix                 string  `json:"currencyPrefix,omitempty"`
+	CurrencySuffix                 string  `json:"currencySuffix,omitempty"`
+	CurrencyGroupSeparator         string  `json:"currencyGroupSeparator,omitempty"`
+	CurrencyDecimalSeparator       string  `json:"currencyDecimalSeparator,omitempty"`
+	CurrencyPrecision              int     `json:"currencyPrecision,omitempty"`
+	CurrencyTruncateZeroFractional *bool   `json:"currencyTruncateZeroFractional,omitempty"`
+	CurrencyRate                   float64 `json:"currencyRate,omitempty"`
+	WeightUnit                     string  `json:"weightUnit,omitempty"`
+	WeightPrecision                int     `json:"weightPrecision,omitempty"`
+	WeightGroupSeparator           string  `json:"weightGroupSeparator,omitempty"`
+	WeightDecimalSeparator         string  `json:"weightDecimalSeparator,omitempty"`
+	WeightTruncateZeroFractional   *bool   `json:"weightTruncateZeroFractional,omitempty"`
+	DateFormat                     string  `json:"dateFormat,omitempty"`
+	TimeFormat                     string  `json:"timeFormat,omitempty"`
+	Timezone                       string  `json:"timezone,omitempty"`
+	DimensionsUnit                 string  `json:"dimensionsUnit,omitempty"`
+	OrderNumberPrefix              string  `json:"orderNumberPrefix,omitempty"`
+	OrderNumberSuffix              string  `json:"orderNumberSuffix,omitempty"`
+}
+
+// Languages holds store language settings.
+type Languages struct {
+	EnabledLanguages []string `json:"enabledLanguages,omitempty"`
+	DefaultLanguage  string   `json:"defaultLanguage,omitempty"`
+	FbMessengerLang  string   `json:"facebookPreferredLocale,omitempty"`
+}
+
+// Shipping holds store shipping settings.
+type Shipping struct {
+	HandlingFee *HandlingFee `json:"handlingFee,omitempty"`
+}
+
+// HandlingFee represents a handling fee configuration.
+type HandlingFee struct {
+	Name        string  `json:"name,omitempty"`
+	Value       float64 `json:"value,omitempty"`
+	Description string  `json:"description,omitempty"`
+}
+
+// TaxSettings holds store tax settings.
+type TaxSettings struct {
+	AutomaticTaxEnabled *bool `json:"automaticTaxEnabled,omitempty"`
+	Taxes               []Tax `json:"taxes,omitempty"`
+}
+
+// Tax represents a tax configuration.
+type Tax struct {
+	ID                 int64           `json:"id"`
+	Name               string          `json:"name,omitempty"`
+	Enabled            *bool           `json:"enabled,omitempty"`
+	IncludeInPrice     *bool           `json:"includeInPrice,omitempty"`
+	UseShippingAddress *bool           `json:"useShippingAddress,omitempty"`
+	TaxShipping        *bool           `json:"taxShipping,omitempty"`
+	AppliedByDefault   *bool           `json:"appliedByDefault,omitempty"`
+	DefaultTax         float64         `json:"defaultTax,omitempty"`
+	Rules              json.RawMessage `json:"rules,omitempty"`
+}
+
+// Zone represents a destination zone.
+type Zone struct {
+	ID                   string          `json:"id,omitempty"`
+	Name                 string          `json:"name,omitempty"`
+	CountryCodes         []string        `json:"countryCodes,omitempty"`
+	StateOrProvinceCodes []string        `json:"stateOrProvinceCodes,omitempty"`
+	Postcode             json.RawMessage `json:"postcode,omitempty"`
+}
+
+// BusinessRegistration holds business registration ID info.
+type BusinessRegistration struct {
+	Name  string `json:"name,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// LegalPagesSettings holds legal page configurations.
+type LegalPagesSettings struct {
+	RequireTermsAgreementAtCheckout *bool       `json:"requireTermsAgreementAtCheckout,omitempty"`
+	LegalPages                      []LegalPage `json:"legalPages,omitempty"`
+}
+
+// LegalPage represents a single legal page.
+type LegalPage struct {
+	Type        string `json:"type,omitempty"`
+	Enabled     *bool  `json:"enabled,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Display     string `json:"display,omitempty"`
+	Text        string `json:"text,omitempty"`
+	ExternalURL string `json:"externalUrl,omitempty"`
+}
+
+// UpdateRequest holds fields for updating the store profile.
+// All fields are optional — only set fields are sent.
+type UpdateRequest struct {
+	GeneralInfo     *GeneralInfo     `json:"generalInfo,omitempty"`
+	Settings        *Settings        `json:"settings,omitempty"`
+	MailSettings    *MailSettings    `json:"mailNotifications,omitempty"`
+	Company         *Company         `json:"company,omitempty"`
+	FormatsAndUnits *FormatsAndUnits `json:"formatsAndUnits,omitempty"`
+	Languages       *Languages       `json:"languages,omitempty"`
+	TaxSettings     *TaxSettings     `json:"taxSettings,omitempty"`
+}
+
+// UpdateResult represents the response from an update operation.
+type UpdateResult struct {
+	UpdateCount int `json:"updateCount"`
+}


### PR DESCRIPTION
Implement ProfileService with Get and Update operations for store profile (`/profile`).

This covers the core profile CRUD. Additional store settings endpoints (shipping, payment, legal pages, etc.) can be added as follow-up.

Closes #7