### PR TITLE
test(e2e): CLI end-to-end tests

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -8,10 +8,17 @@ All tests require `ECWID_E2E=1` — they are skipped entirely otherwise.
 
 ## Secrets needed
 
-| Variable         | Description                        |
-|------------------|------------------------------------|
-| `ECWID_STORE_ID` | Ecwid store ID                     |
-| `ECWID_TOKEN`    | API access token with full scopes  |
+| Variable         | Description                        | Required for         |
+|------------------|------------------------------------|----------------------|
+| `ECWID_STORE_ID` | Ecwid store ID                     | API + CLI API tests  |
+| `ECWID_TOKEN`    | API access token with full scopes  | API + CLI API tests  |
+
+CLI tests for `version`, `--help`, missing credentials, and invalid store ID run without secrets.
+
+## Test categories
+
+- **API tests** (`*_test.go` except `cli_test.go`): call `requireClient(t)` to skip when credentials are missing.
+- **CLI tests** (`cli_test.go`): invoke the compiled `ecwid` binary via `os/exec`. Tests needing real API access call `requireCredentialEnv(t)`.
 
 ## Rules
 
@@ -21,6 +28,7 @@ All tests require `ECWID_E2E=1` — they are skipped entirely otherwise.
 - **Read-only tests first**: dictionaries, reports don't mutate state.
 - **CRUD tests**: create test data with unique names, clean up in `t.Cleanup`.
 - **Timeouts**: use `testContext(t)` helper (30s per request). HTTP client has 60s timeout.
+- **API tests**: always call `requireClient(t)` at the start of each test function.
 
 ## Adding tests for new domains
 

--- a/e2e/categories_test.go
+++ b/e2e/categories_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCategories_Search(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Categories.Search(ctx, &categories.SearchOptions{Limit: 5})
@@ -20,6 +21,7 @@ func TestCategories_Search(t *testing.T) {
 }
 
 func TestCategories_CRUD(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	// Create

--- a/e2e/categories_test.go
+++ b/e2e/categories_test.go
@@ -37,10 +37,10 @@ func TestCategories_CRUD(t *testing.T) {
 	}
 	catID := created.ID
 
-	// Clean up at the end
-	defer func() {
+	// Clean up at the end.
+	t.Cleanup(func() {
 		_, _ = testClient.Categories.Delete(testContext(t), catID)
-	}()
+	})
 
 	// Get
 	cat, err := testClient.Categories.Get(ctx, catID)

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -1,0 +1,228 @@
+package e2e
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// cliResult holds the output of a CLI invocation.
+type cliResult struct {
+	stdout   string
+	stderr   string
+	exitCode int
+}
+
+// runBinary executes the compiled CLI binary with the given args and environment.
+// baseEnv is merged on top of a minimal environment (PATH only).
+func runBinary(t *testing.T, env []string, args ...string) cliResult {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, args...)
+	// Start with a clean environment to avoid inheriting user config.
+	cmd.Env = append([]string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}, env...)
+	cmd.Stdin = strings.NewReader("") // prevent hanging
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	exitCode := 0
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		exitCode = exitErr.ExitCode()
+	} else if err != nil {
+		t.Fatalf("failed to run CLI: %v", err)
+	}
+
+	return cliResult{
+		stdout:   stdout.String(),
+		stderr:   stderr.String(),
+		exitCode: exitCode,
+	}
+}
+
+// requireCredentialEnv returns env vars for the real Ecwid API, or skips the test.
+func requireCredentialEnv(t *testing.T) []string {
+	t.Helper()
+	storeID := os.Getenv("ECWID_STORE_ID")
+	token := os.Getenv("ECWID_TOKEN")
+	if storeID == "" || token == "" {
+		t.Skip("skipping: ECWID_STORE_ID and ECWID_TOKEN required")
+	}
+	return []string{
+		"ECWID_STORE_ID=" + storeID,
+		"ECWID_TOKEN=" + token,
+	}
+}
+
+// ── Version / Help (no credentials needed) ──────────────────────────────
+
+func TestCLI_Version(t *testing.T) {
+	r := runBinary(t, nil, "version")
+	if r.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", r.exitCode, r.stderr)
+	}
+	if !strings.HasPrefix(r.stdout, "ecwid-cli ") {
+		t.Errorf("expected output starting with 'ecwid-cli ', got %q", r.stdout)
+	}
+}
+
+func TestCLI_Help(t *testing.T) {
+	r := runBinary(t, nil, "--help")
+	if r.exitCode != 0 {
+		t.Fatalf("expected exit 0, got %d: %s", r.exitCode, r.stderr)
+	}
+	if !strings.Contains(r.stdout, "Ecwid") {
+		t.Errorf("expected help output to mention Ecwid, got %q", r.stdout)
+	}
+}
+
+func TestCLI_SubcommandHelp(t *testing.T) {
+	t.Parallel()
+	for _, sub := range []string{
+		"products", "orders", "categories", "customers",
+		"dictionaries", "profile", "carts", "subscriptions",
+		"promotions", "coupons", "reviews", "staff", "domains", "reports",
+	} {
+		t.Run(sub, func(t *testing.T) {
+			t.Parallel()
+			r := runBinary(t, nil, sub, "--help")
+			if r.exitCode != 0 {
+				t.Fatalf("%s --help: exit %d: %s", sub, r.exitCode, r.stderr)
+			}
+		})
+	}
+}
+
+// ── Missing credentials ─────────────────────────────────────────────────
+
+func TestCLI_MissingCredentials(t *testing.T) {
+	r := runBinary(t, nil, "profile", "get")
+	if r.exitCode == 0 {
+		t.Fatal("expected non-zero exit code when credentials are missing")
+	}
+}
+
+// ── Config file loading ─────────────────────────────────────────────────
+
+func TestCLI_ConfigFile(t *testing.T) {
+	env := requireCredentialEnv(t)
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
+	cfgContent := "store_id: " + os.Getenv("ECWID_STORE_ID") + "\ntoken: " + os.Getenv("ECWID_TOKEN") + "\n"
+	if err := os.WriteFile(cfgPath, []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use --config flag; don't pass store-id/token via env so config file is the source.
+	r := runBinary(t, nil, "--config", cfgPath, "dictionaries", "countries")
+	if r.exitCode != 0 {
+		t.Fatalf("config file test: exit %d: %s", r.exitCode, r.stderr)
+	}
+	if !strings.Contains(r.stdout, "US") {
+		t.Errorf("expected US in output, got %q", r.stdout)
+	}
+	_ = env // credentials validated above
+}
+
+// ── Env var loading ─────────────────────────────────────────────────────
+
+func TestCLI_EnvVarLoading(t *testing.T) {
+	env := requireCredentialEnv(t)
+
+	r := runBinary(t, env, "dictionaries", "countries")
+	if r.exitCode != 0 {
+		t.Fatalf("env var loading: exit %d: %s", r.exitCode, r.stderr)
+	}
+	if !strings.Contains(r.stdout, "US") {
+		t.Errorf("expected US in output, got %q", r.stdout)
+	}
+}
+
+// ── Flag precedence over env ────────────────────────────────────────────
+
+func TestCLI_FlagPrecedence(t *testing.T) {
+	env := requireCredentialEnv(t)
+
+	// Pass correct store-id via flag, wrong one via env.
+	storeID := os.Getenv("ECWID_STORE_ID")
+	flagEnv := []string{
+		"ECWID_STORE_ID=wrong-store-id",
+		"ECWID_TOKEN=" + os.Getenv("ECWID_TOKEN"),
+	}
+
+	r := runBinary(t, flagEnv, "--store-id", storeID, "dictionaries", "countries")
+	if r.exitCode != 0 {
+		t.Fatalf("flag precedence: exit %d: %s", r.exitCode, r.stderr)
+	}
+	if !strings.Contains(r.stdout, "US") {
+		t.Errorf("expected US in output, got %q", r.stdout)
+	}
+	_ = env
+}
+
+// ── JSON output ─────────────────────────────────────────────────────────
+
+func TestCLI_OutputJSON(t *testing.T) {
+	env := requireCredentialEnv(t)
+
+	r := runBinary(t, env, "--output", "json", "dictionaries", "countries")
+	if r.exitCode != 0 {
+		t.Fatalf("json output: exit %d: %s", r.exitCode, r.stderr)
+	}
+	// JSON output should contain indented brackets.
+	if !strings.Contains(r.stdout, "[\n") {
+		t.Errorf("expected JSON array with newlines, got %q", r.stdout)
+	}
+}
+
+// ── Table output ────────────────────────────────────────────────────────
+
+func TestCLI_OutputTable(t *testing.T) {
+	env := requireCredentialEnv(t)
+
+	r := runBinary(t, env, "--output", "table", "dictionaries", "countries")
+	if r.exitCode != 0 {
+		t.Fatalf("table output: exit %d: %s", r.exitCode, r.stderr)
+	}
+	// Table output should have uppercase headers.
+	if !strings.Contains(r.stdout, "CODE") {
+		t.Errorf("expected CODE header in table output, got %q", r.stdout)
+	}
+}
+
+// ── Real API: dictionaries countries ─────────────────────────────────────
+
+func TestCLI_Dictionaries_Countries(t *testing.T) {
+	env := requireCredentialEnv(t)
+
+	r := runBinary(t, env, "dictionaries", "countries")
+	if r.exitCode != 0 {
+		t.Fatalf("dictionaries countries: exit %d: %s", r.exitCode, r.stderr)
+	}
+	if !strings.Contains(r.stdout, "United States") {
+		t.Errorf("expected 'United States' in output, got %q", r.stdout)
+	}
+}
+
+// ── Invalid store ID ────────────────────────────────────────────────────
+
+func TestCLI_InvalidStoreID(t *testing.T) {
+	env := []string{
+		"ECWID_STORE_ID=0",
+		"ECWID_TOKEN=invalid-token-for-e2e-test",
+	}
+
+	r := runBinary(t, env, "profile", "get")
+	if r.exitCode == 0 {
+		t.Fatal("expected non-zero exit code for invalid store ID")
+	}
+}

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -17,16 +17,26 @@ type cliResult struct {
 }
 
 // runBinary executes the compiled CLI binary with the given args and environment.
-// baseEnv is merged on top of a minimal environment (PATH only).
+// env is merged on top of a minimal environment (PATH and a temporary HOME).
 func runBinary(t *testing.T, env []string, args ...string) cliResult {
 	t.Helper()
 
 	cmd := exec.Command(binaryPath, args...)
-	// Start with a clean environment to avoid inheriting user config.
-	cmd.Env = append([]string{
-		"PATH=" + os.Getenv("PATH"),
-		"HOME=" + t.TempDir(),
-	}, env...)
+
+	// Use a map so caller-provided variables override defaults.
+	envMap := map[string]string{
+		"PATH": os.Getenv("PATH"),
+		"HOME": t.TempDir(),
+	}
+	for _, e := range env {
+		if key, value, ok := strings.Cut(e, "="); ok {
+			envMap[key] = value
+		}
+	}
+	cmd.Env = make([]string, 0, len(envMap))
+	for key, value := range envMap {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
 	cmd.Stdin = strings.NewReader("") // prevent hanging
 
 	var stdout, stderr bytes.Buffer
@@ -113,7 +123,7 @@ func TestCLI_MissingCredentials(t *testing.T) {
 // ── Config file loading ─────────────────────────────────────────────────
 
 func TestCLI_ConfigFile(t *testing.T) {
-	env := requireCredentialEnv(t)
+	requireCredentialEnv(t) // gate: skip if credentials unavailable
 
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
@@ -130,7 +140,6 @@ func TestCLI_ConfigFile(t *testing.T) {
 	if !strings.Contains(r.stdout, "US") {
 		t.Errorf("expected US in output, got %q", r.stdout)
 	}
-	_ = env // credentials validated above
 }
 
 // ── Env var loading ─────────────────────────────────────────────────────
@@ -150,7 +159,7 @@ func TestCLI_EnvVarLoading(t *testing.T) {
 // ── Flag precedence over env ────────────────────────────────────────────
 
 func TestCLI_FlagPrecedence(t *testing.T) {
-	env := requireCredentialEnv(t)
+	requireCredentialEnv(t) // gate: skip if credentials unavailable
 
 	// Pass correct store-id via flag, wrong one via env.
 	storeID := os.Getenv("ECWID_STORE_ID")
@@ -166,7 +175,6 @@ func TestCLI_FlagPrecedence(t *testing.T) {
 	if !strings.Contains(r.stdout, "US") {
 		t.Errorf("expected US in output, got %q", r.stdout)
 	}
-	_ = env
 }
 
 // ── JSON output ─────────────────────────────────────────────────────────

--- a/e2e/customers_test.go
+++ b/e2e/customers_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCustomers_Search(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Customers.Search(ctx, &customers.SearchOptions{Limit: 5})
@@ -20,6 +21,7 @@ func TestCustomers_Search(t *testing.T) {
 }
 
 func TestCustomers_CRUD(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	// Create

--- a/e2e/dictionaries_test.go
+++ b/e2e/dictionaries_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestDictionaries_Countries(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	countries, err := testClient.Dictionaries.Countries(ctx, nil)
@@ -33,6 +34,7 @@ func TestDictionaries_Countries(t *testing.T) {
 }
 
 func TestDictionaries_CountriesWithStates(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	countries, err := testClient.Dictionaries.Countries(ctx, &dictionaries.CountriesOptions{
@@ -55,6 +57,7 @@ func TestDictionaries_CountriesWithStates(t *testing.T) {
 }
 
 func TestDictionaries_Currencies(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	currencies, err := testClient.Dictionaries.Currencies(ctx, "en")
@@ -78,6 +81,7 @@ func TestDictionaries_Currencies(t *testing.T) {
 }
 
 func TestDictionaries_CurrencyByCountry(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	currencies, err := testClient.Dictionaries.CurrencyByCountry(ctx, "DE", "en")
@@ -101,6 +105,7 @@ func TestDictionaries_CurrencyByCountry(t *testing.T) {
 }
 
 func TestDictionaries_States(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	states, err := testClient.Dictionaries.States(ctx, "US", "en")
@@ -124,6 +129,7 @@ func TestDictionaries_States(t *testing.T) {
 }
 
 func TestDictionaries_TaxClasses(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	taxClasses, err := testClient.Dictionaries.TaxClasses(ctx, "US", "en")

--- a/e2e/discounts_test.go
+++ b/e2e/discounts_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestDiscounts_SearchPromotions(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Discounts.SearchPromotions(ctx)
@@ -16,6 +17,7 @@ func TestDiscounts_SearchPromotions(t *testing.T) {
 }
 
 func TestDiscounts_SearchCoupons(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Discounts.SearchCoupons(ctx, nil)

--- a/e2e/domains_test.go
+++ b/e2e/domains_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestDomains_Get(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Domains.Get(ctx)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -73,6 +73,7 @@ func TestMain(m *testing.M) {
 	buildCmd.Stderr = os.Stderr
 	if err := buildCmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to build CLI binary: %v\n", err)
+		_ = os.RemoveAll(tmpDir)
 		os.Exit(1)
 	}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,8 +3,8 @@
 // Requires environment variables:
 //
 //	ECWID_E2E=1          — gate flag
-//	ECWID_STORE_ID       — Ecwid store ID
-//	ECWID_TOKEN          — API access token
+//	ECWID_STORE_ID       — Ecwid store ID (required for API tests)
+//	ECWID_TOKEN          — API access token (required for API tests)
 package e2e
 
 import (
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -21,6 +23,9 @@ import (
 )
 
 var testClient *ecwid.Client
+
+// binaryPath is the path to the compiled CLI binary, built once in TestMain.
+var binaryPath string
 
 // defaultTimeout is the per-request timeout for E2E tests.
 const defaultTimeout = 30 * time.Second
@@ -31,6 +36,14 @@ func testContext(t *testing.T) context.Context {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+// requireClient skips the test if the API client is not available (missing credentials).
+func requireClient(t *testing.T) {
+	t.Helper()
+	if testClient == nil {
+		t.Skip("skipping: ECWID_STORE_ID and ECWID_TOKEN required for API tests")
+	}
 }
 
 // skipIfForbidden skips the test if the error is a 403 Forbidden API error.
@@ -49,6 +62,21 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
+	// Build the CLI binary once for all CLI E2E tests.
+	tmpDir, err := os.MkdirTemp("", "ecwid-e2e-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	binaryPath = filepath.Join(tmpDir, "ecwid")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, "../cli/")
+	buildCmd.Stderr = os.Stderr
+	if err := buildCmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build CLI binary: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Set up API client if credentials are available.
 	cfg := config.Config{
 		StoreID:    os.Getenv("ECWID_STORE_ID"),
 		Token:      os.Getenv("ECWID_TOKEN"),
@@ -57,13 +85,14 @@ func TestMain(m *testing.M) {
 	cfg = cfg.WithDefaults()
 
 	if err := cfg.Validate(); err != nil {
-		fmt.Fprintf(os.Stderr, "E2E config invalid: %v\n", err)
-		fmt.Fprintf(os.Stderr, "Required: ECWID_STORE_ID and ECWID_TOKEN environment variables\n")
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "API credentials not configured: %v\n", err)
+		fmt.Fprintf(os.Stderr, "API client tests will be skipped; CLI-only tests will still run\n")
+	} else {
+		httpClient := &http.Client{Timeout: 60 * time.Second}
+		testClient = ecwid.NewClient(cfg, ecwid.WithHTTPClient(httpClient))
 	}
 
-	httpClient := &http.Client{Timeout: 60 * time.Second}
-	testClient = ecwid.NewClient(cfg, ecwid.WithHTTPClient(httpClient))
-
-	os.Exit(m.Run())
+	code := m.Run()
+	_ = os.RemoveAll(tmpDir)
+	os.Exit(code)
 }

--- a/e2e/orders_test.go
+++ b/e2e/orders_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestOrders_Search(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Orders.Search(ctx, &orders.SearchOptions{Limit: 5})
@@ -22,6 +23,7 @@ func TestOrders_Search(t *testing.T) {
 }
 
 func TestOrders_CRUD(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	items, _ := json.Marshal([]map[string]any{

--- a/e2e/products_test.go
+++ b/e2e/products_test.go
@@ -100,9 +100,9 @@ func TestProducts_CRUD(t *testing.T) {
 	prodID := created.ID
 
 	// Clean up at the end.
-	defer func() {
+	t.Cleanup(func() {
 		_, _ = testClient.Products.Delete(testContext(t), prodID)
-	}()
+	})
 
 	// Get
 	prod, err := testClient.Products.Get(ctx, prodID)

--- a/e2e/products_test.go
+++ b/e2e/products_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestProducts_Search(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Products.Search(ctx, &products.SearchOptions{Limit: 5})
@@ -20,6 +21,7 @@ func TestProducts_Search(t *testing.T) {
 }
 
 func TestProducts_SearchWithFilters(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	// Create a product with a known price to search for.
@@ -78,6 +80,7 @@ func TestProducts_SearchWithFilters(t *testing.T) {
 }
 
 func TestProducts_CRUD(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	// Create

--- a/e2e/profile_test.go
+++ b/e2e/profile_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestProfile_Get(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	p, err := testClient.Profile.Get(ctx)

--- a/e2e/ratelimit_test.go
+++ b/e2e/ratelimit_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestRateLimit_Handling(t *testing.T) {
+	requireClient(t)
 	// Fire many concurrent requests to try to trigger a 429.
 	// The client is configured with MaxRetries: 3, so rate-limited
 	// requests should be retried automatically.

--- a/e2e/reports_test.go
+++ b/e2e/reports_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestReports_GetReport(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	report, err := testClient.Reports.GetReport(ctx, "allOrders", &reports.ReportOptions{
@@ -22,6 +23,7 @@ func TestReports_GetReport(t *testing.T) {
 }
 
 func TestReports_LatestStats(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	stats, err := testClient.Reports.LatestStats(ctx, &reports.LatestStatsOptions{

--- a/e2e/reviews_test.go
+++ b/e2e/reviews_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestReviews_Search(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Reviews.Search(ctx, nil)

--- a/e2e/staff_test.go
+++ b/e2e/staff_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestStaff_List(t *testing.T) {
+	requireClient(t)
 	ctx := testContext(t)
 
 	result, err := testClient.Staff.List(ctx)


### PR DESCRIPTION
## Summary
- Add CLI E2E tests (`e2e/cli_test.go`) that invoke the compiled `ecwid` binary and verify exit codes, stdout/stderr, and output formatting against the real Ecwid API
- Tests cover: `version`, `--help`, subcommand help, config file loading, env var loading, flag precedence, JSON/table output, missing credentials, invalid store ID, and `dictionaries countries`
- Make `TestMain` credentials optional — CLI-only tests (version, help, missing creds, invalid store ID) run without `ECWID_STORE_ID`/`ECWID_TOKEN`
- Add `requireClient(t)` guard to all existing API tests so they skip gracefully when credentials are missing

## Test plan
- [x] CLI tests without credentials pass: `ECWID_E2E=1 go test ./... -run "TestCLI_(Version|Help|SubcommandHelp|MissingCredentials|InvalidStoreID)"`
- [x] Credential-requiring tests skip properly without secrets
- [x] Existing API tests skip with `requireClient(t)` when no credentials
- [x] `task lint` passes
- [x] `task test` passes
- [ ] Full E2E suite with credentials in CI

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive CLI end-to-end tests covering version/help, subcommand help, missing/invalid credentials, config/env loading, output formats, and API-backed commands.
  * Introduced a pre-test CLI build step and conditional API vs. CLI-only test execution when credentials are absent.
  * Standardized test setup: client-initialization checks added across API tests and use of test cleanup hooks.

* **Documentation**
  * Updated test docs with new "Test categories", secrets table, and requirement that API tests call the client-setup helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->