### PR TITLE
fix(client): make logging opt-in (no-op logger by default)

### DIFF
--- a/ecwid/client.go
+++ b/ecwid/client.go
@@ -63,7 +63,9 @@ func WithHTTPClient(c *http.Client) Option {
 	}
 }
 
-// WithLogger sets a custom slog logger. A nil value is ignored.
+// WithLogger sets a custom slog logger. A nil value is ignored. By default the
+// client logs nothing (a no-op handler); pass a logger to opt into request
+// (debug) and rate-limit retry (warn) logging. Credentials are never logged.
 func WithLogger(l *slog.Logger) Option {
 	return func(o *options) {
 		if l != nil {

--- a/ecwid/internal/api/httpclient.go
+++ b/ecwid/internal/api/httpclient.go
@@ -40,9 +40,11 @@ func NewHTTPClient(cfg HTTPClientConfig) *HTTPClient {
 		httpClient = http.DefaultClient
 	}
 
+	// Default to a no-op logger: a library should stay silent unless the caller
+	// opts in via WithLogger, rather than emitting to the global slog.Default().
 	logger := cfg.Logger
 	if logger == nil {
-		logger = slog.Default()
+		logger = slog.New(slog.DiscardHandler)
 	}
 
 	// Wrap transport with retry if configured.

--- a/ecwid/internal/api/httpclient_test.go
+++ b/ecwid/internal/api/httpclient_test.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -159,5 +162,75 @@ func TestHTTPClient_Retries(t *testing.T) {
 	}
 	if attempts != 3 {
 		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+// rateLimitOnceServer returns a server that answers the first request with 429
+// (Retry-After: 0) and the second with 200, forcing exactly one retry.
+func rateLimitOnceServer() *httptest.Server {
+	attempts := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+}
+
+// TestHTTPClient_DefaultLoggerIsSilent verifies that, without an explicit
+// logger, the client does not emit to slog.Default() — a library should stay
+// silent unless the caller opts in.
+func TestHTTPClient_DefaultLoggerIsSilent(t *testing.T) {
+	srv := rateLimitOnceServer()
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	c := NewHTTPClient(HTTPClientConfig{
+		BaseURL:    srv.URL + "/api/v3",
+		StoreID:    "123",
+		Token:      "test_token",
+		MaxRetries: 2,
+	})
+
+	var result struct{ OK bool }
+	if err := c.Get(context.Background(), "/test", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output on slog.Default(), got: %s", buf.String())
+	}
+}
+
+// TestHTTPClient_LoggerReceivesRetryWarn verifies that an explicitly configured
+// logger still receives the rate-limit retry warning.
+func TestHTTPClient_LoggerReceivesRetryWarn(t *testing.T) {
+	srv := rateLimitOnceServer()
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	c := NewHTTPClient(HTTPClientConfig{
+		BaseURL:    srv.URL + "/api/v3",
+		StoreID:    "123",
+		Token:      "test_token",
+		MaxRetries: 2,
+		Logger:     logger,
+	})
+
+	var result struct{ OK bool }
+	if err := c.Get(context.Background(), "/test", nil, &result); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "rate limited, retrying") {
+		t.Errorf("expected retry warning in log, got: %s", buf.String())
 	}
 }

--- a/ecwid/internal/api/retry.go
+++ b/ecwid/internal/api/retry.go
@@ -48,7 +48,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		logger := t.logger
 		if logger == nil {
-			logger = slog.Default()
+			logger = slog.New(slog.DiscardHandler)
 		}
 		logger.Warn("rate limited, retrying",
 			"attempt", attempt+1,


### PR DESCRIPTION
## What

When no logger is configured, the client fell back to `slog.Default()` in both `NewHTTPClient` and the retry transport. This means merely importing the library and hitting a `429` (or enabling debug on the app's global logger) emits the library's log lines into the consuming application's global logger — output the app author never opted into.

This changes the default to a **no-op logger** (`slog.New(slog.DiscardHandler)`), so the client is silent unless the caller explicitly opts in via `WithLogger` / `HTTPClientConfig.Logger`. This is the idiomatic Go-library posture and pairs cleanly with consumers that want the client's logs routed to *their* structured logger.

## Changes

- `ecwid/internal/api/httpclient.go` — default logger is now a discard handler, not `slog.Default()`.
- `ecwid/internal/api/retry.go` — same default in the retry transport's fallback.
- `ecwid/client.go` — documented the default on `WithLogger`.
- `ecwid/internal/api/httpclient_test.go` — two tests: (1) with no logger, nothing is written to `slog.Default()` even across a rate-limit retry; (2) with an explicit logger, the rate-limit retry warning is still emitted.

## Behavior change / compatibility

No API surface change. The only behavioral change: callers who relied on the client implicitly logging to `slog.Default()` must now pass `WithLogger(slog.Default())` to keep that behavior. Given logging was request-level `Debug` (off by default) plus rate-limit `Warn`, the practical impact is limited to unsolicited rate-limit warnings no longer appearing.

## Verification

`ecwid` module: `golangci-lint run ./...` → 0 issues; `go test ./... -race` → all pass (pre-existing `cli` module govet hints are unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified default logging behavior, including that credentials are never logged.

* **Bug Fixes**
  * HTTP requests and retry warnings are now silent by default unless logging is explicitly enabled.
  * Preserved retry warnings when a logger is configured, including rate-limit retry messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->