### PR TITLE
feat(instantsite): add full Instant Site API client, CLI, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Go client library and CLI for the [Ecwid REST API](https://docs.ecwid.com/api-re
 
 ## Features
 
-- **Full Ecwid API coverage** — Products, Orders, Customers, Categories, Carts, Subscriptions, Promotions, Coupons, Reviews, Store Profile, Staff, Domains, Dictionaries, Reports
+- **Full Ecwid API coverage** — Products, Orders, Customers, Categories, Carts, Subscriptions, Promotions, Coupons, Reviews, Store Profile, Staff, Domains, Instant Site, Dictionaries, Reports
 - **Stdlib only** — Zero external dependencies in config and client modules
 - **Stateless** — No internal state; credentials passed explicitly per client
 - **Multi-module** — Clean separation: `config/`, `ecwid/`, `cli/` with independent `go.mod`s
@@ -171,6 +171,7 @@ Ecwid allows **600 requests/minute per token**.
 | Promotions | `PromotionService` | 🔲 |
 | Discount Coupons | `CouponService` | 🔲 |
 | Domains | `DomainService` | 🔲 |
+| Instant Site | `InstantSiteService` | ✅ |
 | Dictionaries | `DictionaryService` | 🔲 |
 | Staff | `StaffService` | 🔲 |
 | Reports | `ReportService` | 🔲 |

--- a/cli/cmd/instantsite/instantsite.go
+++ b/cli/cmd/instantsite/instantsite.go
@@ -1,0 +1,641 @@
+// Package instantsite implements the "instantsite" CLI command group for the
+// Ecwid Instant Site API.
+package instantsite
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/matthiasbruns/ecwid-go/cli/internal/cmdutil"
+	api "github.com/matthiasbruns/ecwid-go/ecwid/instantsite"
+)
+
+// Cmd is the top-level instantsite command.
+var Cmd = &cobra.Command{
+	Use:   "instantsite",
+	Short: "Manage the store's Instant Site (pages, tiles, themes, redirects)",
+}
+
+// decodeInput reads JSON from --file or stdin and unmarshals it into v.
+func decodeInput(cmd *cobra.Command, v any, what string) error {
+	data, err := cmdutil.ReadInput(cmd)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("invalid %s JSON: %w", what, err)
+	}
+	return nil
+}
+
+// fileFlag adds the standard --file flag to a body-reading command.
+func fileFlag(c *cobra.Command) *cobra.Command {
+	c.Flags().String("file", "", "path to JSON file (reads stdin if omitted)")
+	return c
+}
+
+func init() {
+	Cmd.AddCommand(
+		tokenCmd(),
+		profileCmd(),
+		lifecycleCmds(),
+		pagesCmd(),
+		tilesCmd(),
+		imagesCmd(),
+		themesCmd(),
+		textLabelsCmd(),
+		redirectsCmd(),
+	)
+}
+
+// ── Token ─────────────────────────────────────────────────────────────────
+
+func tokenCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "token",
+		Short: "Exchange an app secret token for an Instant Site access token",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			siteID, _ := cmd.Flags().GetString("site-id")
+			code, _ := cmd.Flags().GetString("code")
+			grantType, _ := cmd.Flags().GetString("grant-type")
+			result, err := cmdutil.AppClient.InstantSite.Token(cmd.Context(), &api.TokenRequest{
+				GrantType: grantType,
+				SiteID:    siteID,
+				Code:      code,
+			})
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+	c.Flags().String("site-id", "", "store ID (site_id) to exchange the token for")
+	c.Flags().String("code", "", "app secret token with the manage_instant_site scope")
+	c.Flags().String("grant-type", api.GrantTypeAuthorizationCode, "grant type: authorization_code or draft_code")
+	_ = c.MarkFlagRequired("site-id")
+	_ = c.MarkFlagRequired("code")
+	return c
+}
+
+// ── Profile ───────────────────────────────────────────────────────────────
+
+func profileCmd() *cobra.Command {
+	c := &cobra.Command{Use: "profile", Short: "Manage the Instant Site profile"}
+
+	get := &cobra.Command{
+		Use:   "get",
+		Short: "Get the Instant Site profile",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := cmdutil.AppClient.InstantSite.GetProfile(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	create := fileFlag(&cobra.Command{
+		Use:   "create",
+		Short: "Create the Instant Site profile (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var profile api.Profile
+			if err := decodeInput(cmd, &profile, "profile"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.CreateProfile(cmd.Context(), &profile)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	update := fileFlag(&cobra.Command{
+		Use:   "update",
+		Short: "Update the Instant Site profile (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var profile api.Profile
+			if err := decodeInput(cmd, &profile, "profile"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.UpdateProfile(cmd.Context(), &profile)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	c.AddCommand(get, create, update)
+	return c
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────
+
+func lifecycleCmds() *cobra.Command {
+	c := &cobra.Command{Use: "draft", Short: "Publish, discard, or clone Instant Site draft changes"}
+
+	publish := &cobra.Command{
+		Use:   "publish",
+		Short: "Publish the current Instant Site draft",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cmdutil.AppClient.InstantSite.Publish(cmd.Context()); err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, map[string]any{"published": true})
+		},
+	}
+
+	discard := &cobra.Command{
+		Use:   "discard",
+		Short: "Discard unpublished Instant Site draft changes",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := cmdutil.AppClient.InstantSite.Discard(cmd.Context()); err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, map[string]any{"discarded": true})
+		},
+	}
+
+	clone := fileFlag(&cobra.Command{
+		Use:   "clone",
+		Short: "Clone an Instant Site from another store (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var req api.CloneRequest
+			if err := decodeInput(cmd, &req, "clone request"); err != nil {
+				return err
+			}
+			if err := cmdutil.AppClient.InstantSite.Clone(cmd.Context(), &req); err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, map[string]any{"cloned": true})
+		},
+	})
+
+	c.AddCommand(publish, discard, clone)
+	return c
+}
+
+// ── Pages ─────────────────────────────────────────────────────────────────
+
+func pagesCmd() *cobra.Command {
+	c := &cobra.Command{Use: "pages", Short: "Manage Instant Site pages"}
+
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List Instant Site pages",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			published, _ := cmd.Flags().GetBool("published")
+			result, err := cmdutil.AppClient.InstantSite.ListPages(cmd.Context(), published)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+	list.Flags().Bool("published", false, "list published pages (default: draft)")
+
+	create := fileFlag(&cobra.Command{
+		Use:   "create",
+		Short: "Create a page (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var page api.Page
+			if err := decodeInput(cmd, &page, "page"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.CreatePage(cmd.Context(), &page)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	update := fileFlag(&cobra.Command{
+		Use:   "update <pageId>",
+		Short: "Update a page (reads JSON from stdin or --file)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var page api.Page
+			if err := decodeInput(cmd, &page, "page"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.UpdatePage(cmd.Context(), args[0], &page)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	del := &cobra.Command{
+		Use:   "delete <pageId>",
+		Short: "Delete a page",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.DeletePage(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	c.AddCommand(list, create, update, del)
+	return c
+}
+
+// ── Tiles ─────────────────────────────────────────────────────────────────
+
+func tilesCmd() *cobra.Command {
+	c := &cobra.Command{Use: "tiles", Short: "Manage Instant Site tiles"}
+
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List tiles",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			published, _ := cmd.Flags().GetBool("published")
+			pageID, _ := cmd.Flags().GetString("page-id")
+			lang, _ := cmd.Flags().GetString("lang")
+			result, err := cmdutil.AppClient.InstantSite.ListTiles(cmd.Context(), &api.TileListOptions{
+				Published: published,
+				PageID:    pageID,
+				Lang:      lang,
+			})
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+	list.Flags().Bool("published", false, "list published tiles (default: draft)")
+	list.Flags().String("page-id", "", "filter tiles to a single page")
+	list.Flags().String("lang", "", "2-letter language code for translated text")
+
+	get := &cobra.Command{
+		Use:   "get <tileId>",
+		Short: "Get a single tile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.GetTile(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	create := fileFlag(&cobra.Command{
+		Use:   "create",
+		Short: "Create a tile (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var req api.CreateTileRequest
+			if err := decodeInput(cmd, &req, "tile"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.CreateTile(cmd.Context(), &req)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	update := fileFlag(&cobra.Command{
+		Use:   "update <tileId>",
+		Short: "Update a tile (reads JSON from stdin or --file)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var tile api.TileUpdate
+			if err := decodeInput(cmd, &tile, "tile"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.UpdateTile(cmd.Context(), args[0], &tile)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	updateAll := fileFlag(&cobra.Command{
+		Use:   "update-all",
+		Short: "Update the whole tiles list (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var tiles api.TileBulkUpdate
+			if err := decodeInput(cmd, &tiles, "tiles"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.UpdateTiles(cmd.Context(), &tiles)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	del := &cobra.Command{
+		Use:   "delete <tileId>",
+		Short: "Delete a tile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.DeleteTile(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	showcase := &cobra.Command{
+		Use:   "showcase",
+		Short: "List available tile templates",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := cmdutil.AppClient.InstantSite.TileShowcase(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	config := &cobra.Command{
+		Use:   "config <configType>",
+		Short: "Get the editor config for a tile category type",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.TileConfig(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	c.AddCommand(list, get, create, update, updateAll, del, showcase, config)
+	return c
+}
+
+// ── Tile images ───────────────────────────────────────────────────────────
+
+func imagesCmd() *cobra.Command {
+	c := &cobra.Command{Use: "images", Short: "Manage Instant Site tile images"}
+
+	reserve := &cobra.Command{
+		Use:   "reserve <tileId>",
+		Short: "Reserve an upload slot for a tile image",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.ReserveTileImage(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	get := &cobra.Command{
+		Use:   "get <imageId>",
+		Short: "Get an uploaded tile image",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.GetImage(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	buckets := &cobra.Command{
+		Use:   "buckets",
+		Short: "List image bucket CDN URLs",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := cmdutil.AppClient.InstantSite.ImageBuckets(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	c.AddCommand(reserve, get, buckets)
+	return c
+}
+
+// ── Themes ────────────────────────────────────────────────────────────────
+
+func themesCmd() *cobra.Command {
+	c := &cobra.Command{Use: "themes", Short: "Manage Instant Site themes"}
+
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List saved themes",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := cmdutil.AppClient.InstantSite.ListThemes(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	create := fileFlag(&cobra.Command{
+		Use:   "create",
+		Short: "Create a theme from a color palette (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var colors api.ThemeColors
+			if err := decodeInput(cmd, &colors, "theme colors"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.CreateTheme(cmd.Context(), &colors)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	update := fileFlag(&cobra.Command{
+		Use:   "update <themeId>",
+		Short: "Update a theme (reads JSON from stdin or --file)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var colors api.ThemeColors
+			if err := decodeInput(cmd, &colors, "theme colors"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.UpdateTheme(cmd.Context(), args[0], &colors)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	del := &cobra.Command{
+		Use:   "delete <themeId>",
+		Short: "Delete a theme",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.DeleteTheme(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	current := &cobra.Command{
+		Use:   "current",
+		Short: "Get the currently applied theme palette",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := cmdutil.AppClient.InstantSite.CurrentTheme(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	setCurrent := fileFlag(&cobra.Command{
+		Use:   "set-current",
+		Short: "Set the currently applied theme palette (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var colors api.ThemeColors
+			if err := decodeInput(cmd, &colors, "theme colors"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.UpdateCurrentTheme(cmd.Context(), &colors)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	c.AddCommand(list, create, update, del, current, setCurrent)
+	return c
+}
+
+// ── Text labels ───────────────────────────────────────────────────────────
+
+func textLabelsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "text-labels",
+		Short: "Get Instant Site text labels (i18n translations)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := cmdutil.AppClient.InstantSite.TextLabels(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+}
+
+// ── Redirects ─────────────────────────────────────────────────────────────
+
+func redirectsCmd() *cobra.Command {
+	c := &cobra.Command{Use: "redirects", Short: "Manage 301 URL redirects"}
+
+	search := &cobra.Command{
+		Use:   "search",
+		Short: "Search redirects",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			keyword, _ := cmd.Flags().GetString("keyword")
+			offset, err := cmdutil.GetNonNegativeInt(cmd, "offset")
+			if err != nil {
+				return err
+			}
+			limit, err := cmdutil.GetNonNegativeInt(cmd, "limit")
+			if err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.SearchRedirects(cmd.Context(), &api.RedirectSearchOptions{
+				Keyword: keyword,
+				Offset:  offset,
+				Limit:   limit,
+			})
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+	search.Flags().String("keyword", "", "filter by saved redirect URL")
+	search.Flags().Int("offset", 0, "pagination offset")
+	search.Flags().Int("limit", 0, "pagination limit")
+
+	get := &cobra.Command{
+		Use:   "get <redirectId>",
+		Short: "Get a single redirect",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := cmdutil.AppClient.InstantSite.GetRedirect(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	}
+
+	create := fileFlag(&cobra.Command{
+		Use:   "create",
+		Short: "Create a redirect (reads JSON from stdin or --file)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var redirect api.Redirect
+			if err := decodeInput(cmd, &redirect, "redirect"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.CreateRedirect(cmd.Context(), &redirect)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	update := fileFlag(&cobra.Command{
+		Use:   "update <redirectId>",
+		Short: "Update a redirect (reads JSON from stdin or --file)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var redirect api.Redirect
+			if err := decodeInput(cmd, &redirect, "redirect"); err != nil {
+				return err
+			}
+			result, err := cmdutil.AppClient.InstantSite.UpdateRedirect(cmd.Context(), args[0], &redirect)
+			if err != nil {
+				return err
+			}
+			return cmdutil.OutputResult(cmd, result)
+		},
+	})
+
+	c.AddCommand(search, get, create, update)
+	return c
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matthiasbruns/ecwid-go/cli/cmd/customers"
 	"github.com/matthiasbruns/ecwid-go/cli/cmd/dictionaries"
 	"github.com/matthiasbruns/ecwid-go/cli/cmd/domains"
+	"github.com/matthiasbruns/ecwid-go/cli/cmd/instantsite"
 	"github.com/matthiasbruns/ecwid-go/cli/cmd/orders"
 	"github.com/matthiasbruns/ecwid-go/cli/cmd/products"
 	"github.com/matthiasbruns/ecwid-go/cli/cmd/profile"
@@ -68,6 +69,9 @@ func init() {
 	rootCmd.PersistentFlags().String("log-level", "", "log level: debug|info|warn|error (default: info)")
 	rootCmd.PersistentFlags().String("base-url", "", "API base URL (env: ECWID_BASE_URL)")
 	rootCmd.PersistentFlags().Int("max-retries", 0, "max retries on rate limit (env: ECWID_MAX_RETRIES)")
+	rootCmd.PersistentFlags().String("instant-site-base-url", "", "Instant Site v1 API base URL (env: ECWID_INSTANT_SITE_BASE_URL)")
+	rootCmd.PersistentFlags().String("instant-site-auth-url", "", "Instant Site token-exchange base URL (env: ECWID_INSTANT_SITE_AUTH_URL)")
+	rootCmd.PersistentFlags().String("instant-site-token", "", "Instant Site v1 API access token (env: ECWID_INSTANT_SITE_TOKEN)")
 
 	// Register domain commands.
 	rootCmd.AddCommand(
@@ -77,6 +81,7 @@ func init() {
 		customers.Cmd,
 		dictionaries.Cmd,
 		domains.Cmd,
+		instantsite.Cmd,
 		orders.Cmd,
 		products.Cmd,
 		profile.Cmd,

--- a/cli/integration_test.go
+++ b/cli/integration_test.go
@@ -52,6 +52,11 @@ func runCLIWithStdin(t *testing.T, baseURL, stdin string, args ...string) cliRes
 		"ECWID_STORE_ID="+testStoreID,
 		"ECWID_TOKEN=test-token",
 		"ECWID_BASE_URL="+baseURL,
+		// Instant Site v1 endpoints live on a separate host/token; point them at
+		// the same mock server under distinct prefixes (see newMockServer).
+		"ECWID_INSTANT_SITE_BASE_URL="+baseURL+"/is-v1",
+		"ECWID_INSTANT_SITE_AUTH_URL="+baseURL+"/is-auth",
+		"ECWID_INSTANT_SITE_TOKEN=is-test-token",
 		"HOME="+t.TempDir(), // Prevent loading user's ~/.ecwid.yaml
 	)
 	// Always set stdin to prevent hanging if a command unexpectedly reads.
@@ -108,6 +113,7 @@ func TestCLI_SubcommandHelp(t *testing.T) {
 		"products", "orders", "categories", "customers",
 		"dictionaries", "profile", "carts", "subscriptions",
 		"promotions", "coupons", "reviews", "staff", "domains", "reports",
+		"instantsite",
 	} {
 		t.Run(sub, func(t *testing.T) {
 			t.Parallel()
@@ -680,6 +686,80 @@ func TestCLI_Subscriptions_Get(t *testing.T) {
 		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
 	}
 	assertContains(t, r.stdout, "8001")
+}
+
+// ── Instant Site ────────────────────────────────────────────────────────
+
+func TestCLI_InstantSite_RedirectsSearch(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLI(t, srv.URL, "instantsite", "redirects", "search")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "/old")
+}
+
+func TestCLI_InstantSite_RedirectsCreate(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLIWithStdin(t, srv.URL, `{"fromUrl":"/a","toUrl":"/b"}`, "instantsite", "redirects", "create")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "r2")
+}
+
+func TestCLI_InstantSite_ProfileGet(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLI(t, srv.URL, "instantsite", "profile", "get")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "Test Instant Site")
+}
+
+func TestCLI_InstantSite_PagesList(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLI(t, srv.URL, "instantsite", "pages", "list")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "Home")
+}
+
+func TestCLI_InstantSite_TilesList(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLI(t, srv.URL, "instantsite", "tiles", "list", "--published")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "COVER")
+}
+
+func TestCLI_InstantSite_ThemesList(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLI(t, srv.URL, "instantsite", "themes", "list")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "th1")
+}
+
+func TestCLI_InstantSite_Publish(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLI(t, srv.URL, "instantsite", "draft", "publish")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "published")
+}
+
+func TestCLI_InstantSite_Token(t *testing.T) {
+	srv := newMockServer(t)
+	r := runCLI(t, srv.URL, "instantsite", "token", "--site-id", testStoreID, "--code", "app_secret")
+	if r.exitCode != 0 {
+		t.Fatalf("exit %d: %s", r.exitCode, r.stderr)
+	}
+	assertContains(t, r.stdout, "tok_abc")
 }
 
 // ── Error Handling ──────────────────────────────────────────────────────

--- a/cli/internal/cfg/loader.go
+++ b/cli/internal/cfg/loader.go
@@ -15,12 +15,15 @@ import (
 
 // flagBindings maps CLI flag names (kebab-case) to config keys (snake_case).
 var flagBindings = map[string]string{
-	"store-id":    "store_id",
-	"token":       "token",
-	"output":      "output",
-	"log-level":   "log_level",
-	"base-url":    "base_url",
-	"max-retries": "max_retries",
+	"store-id":              "store_id",
+	"token":                 "token",
+	"output":                "output",
+	"log-level":             "log_level",
+	"base-url":              "base_url",
+	"max-retries":           "max_retries",
+	"instant-site-base-url": "instant_site_base_url",
+	"instant-site-auth-url": "instant_site_auth_url",
+	"instant-site-token":    "instant_site_token",
 }
 
 // Load reads configuration from file, environment, and flags using viper.

--- a/cli/mock_server_test.go
+++ b/cli/mock_server_test.go
@@ -357,6 +357,165 @@ func newMockServer(t *testing.T) *httptest.Server {
 		}
 	})
 
+	// ── Instant Site: redirects (v3, main host) ──────────────────────────
+	handle("/instant-site/redirects", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{
+				"total": 1, "count": 1, "offset": 0, "limit": 10,
+				"items": []map[string]any{
+					{"id": "r1", "fromUrl": "/old", "toUrl": "/new"},
+				},
+			})
+		case http.MethodPost:
+			writeJSON(w, map[string]any{"id": "r2", "fromUrl": "/a", "toUrl": "/b"})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handle("/instant-site/redirects/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"id": "r1", "fromUrl": "/old", "toUrl": "/new"})
+		case http.MethodPut:
+			writeJSON(w, map[string]any{"id": "r1", "fromUrl": "/old", "toUrl": "/newer"})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+
+	// ── Instant Site: v1 host ────────────────────────────────────────────
+	// The CLI/e2e point ECWID_INSTANT_SITE_BASE_URL at srv.URL + "/is-v1" so
+	// these paths don't collide with the main store /profile handler above.
+	handleIS := func(pattern string, h http.HandlerFunc) {
+		mux.HandleFunc("/is-v1/"+testStoreID+pattern, h)
+	}
+	handleIS("/profile", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"siteId": "s1", "storeName": "Test Instant Site", "siteUrl": "https://test.company.site"})
+		case http.MethodPost, http.MethodPut:
+			writeJSON(w, map[string]any{"siteId": "s1", "storeName": "Test Instant Site"})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/publish", func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, map[string]any{}) })
+	handleIS("/discard", func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, map[string]any{}) })
+	handleIS("/clone", func(w http.ResponseWriter, _ *http.Request) { writeJSON(w, map[string]any{}) })
+	handleIS("/page", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"pages": []map[string]any{
+				{"pageId": "p1", "title": "Home", "tileIds": []string{"t1", "t2"}},
+			}})
+		case http.MethodPost:
+			writeJSON(w, map[string]any{"pageId": "p9"})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/page/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			writeJSON(w, map[string]any{"pageId": "p1", "title": "Renamed"})
+		case http.MethodDelete:
+			writeJSON(w, map[string]any{"pageId": "p1"})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/tile", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"tiles": []map[string]any{
+				{"id": "t1", "type": "COVER"},
+			}})
+		case http.MethodPost:
+			writeJSON(w, map[string]any{"id": "t9", "type": "COVER"})
+		case http.MethodPut:
+			writeJSON(w, map[string]any{"tiles": []map[string]any{{"id": "t1"}}})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/tile/showcase", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"categories": []map[string]any{
+			{"type": "COVER", "items": []map[string]any{{"id": "i1"}}},
+		}})
+	})
+	handleIS("/tile/config/", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"type": "COVER", "config": map[string]any{"layoutConfigList": []any{}}})
+	})
+	handleIS("/tile/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/image") && r.Method == http.MethodPost {
+			writeJSON(w, map[string]any{"url": "https://upload.example", "id": "img1"})
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"id": "t1", "type": "COVER"})
+		case http.MethodPut:
+			writeJSON(w, map[string]any{"id": "t1", "tileName": "Renamed"})
+		case http.MethodDelete:
+			writeJSON(w, map[string]any{"id": "t1"})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/image/bucket", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"urls": map[string]any{"eu-fra": "https://d2gt4h1eeousrn.cloudfront.net"}})
+	})
+	handleIS("/image/", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"bucket": "eu-fra", "set": []map[string]any{
+			{"url": "https://cdn.example/x.jpg", "width": 800, "height": 600},
+		}})
+	})
+	handleIS("/themes", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"themes": []map[string]any{
+				{"themeId": "th1", "colors": map[string]any{"colorA": "#fff"}},
+			}})
+		case http.MethodPost:
+			writeJSON(w, map[string]any{"themeId": "th2", "colors": map[string]any{"colorA": "#000"}})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/themes/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			writeJSON(w, map[string]any{"themeId": "th2", "colors": map[string]any{"colorA": "#111"}})
+		case http.MethodDelete:
+			writeJSON(w, map[string]any{"themeId": "th2", "colors": map[string]any{"colorA": "#111"}})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/current_theme", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			writeJSON(w, map[string]any{"colors": map[string]any{"colorA": "#abc"}})
+		case http.MethodPut:
+			writeJSON(w, map[string]any{"themeId": "cur", "colors": map[string]any{"colorA": "#abc"}})
+		default:
+			methodNotAllowed(w, r)
+		}
+	})
+	handleIS("/translation", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"editorTranslations":   map[string]any{"k": "v"},
+			"languageTranslations": map[string]any{"en": map[string]any{"Language.en": "English"}},
+		})
+	})
+
+	// ── Instant Site: token exchange (auth host) ─────────────────────────
+	// The CLI/e2e point ECWID_INSTANT_SITE_AUTH_URL at srv.URL + "/is-auth".
+	mux.HandleFunc("/is-auth/oauth/token", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{"accessToken": "tok_abc", "tokenType": "bearer", "expiresIn": 86400})
+	})
+
 	// ── Retry endpoint (429 then 200) ───────────────────────────────────
 	// Returns 429 on the first request, then 200 with profile data on retry.
 	var retryCount atomic.Int32

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,19 @@ const (
 
 	// DefaultLogLevel is the default log level.
 	DefaultLogLevel = "info"
+
+	// DefaultInstantSiteBaseURL is the default base URL for the Instant Site v1
+	// API (profile, pages, tiles, themes, text labels, publish/discard/clone).
+	//
+	// NOTE: this host is unverified against a live store — the Ecwid docs
+	// consistently render "vuega.ecwid.com" for these v1 endpoints, and the
+	// profile response's ecwidApiUrl field hints the host may be store-specific.
+	// Override via InstantSiteBaseURL if a live call reveals a different host.
+	DefaultInstantSiteBaseURL = "https://vuega.ecwid.com/api/v1"
+
+	// DefaultInstantSiteAuthURL is the default base URL for the Instant Site
+	// OAuth token-exchange endpoint (POST /oauth/token).
+	DefaultInstantSiteAuthURL = "https://app.ecwid.com/instantsite"
 )
 
 // Config holds all configuration for the Ecwid client and CLI.
@@ -38,6 +51,19 @@ type Config struct {
 	// MaxRetries is the maximum number of retries for rate-limited requests.
 	// 0 means no retries. Defaults to 0.
 	MaxRetries int `json:"max_retries,omitempty" yaml:"max_retries,omitempty" mapstructure:"max_retries"`
+
+	// InstantSiteBaseURL is the base URL for the Instant Site v1 API.
+	// Defaults to DefaultInstantSiteBaseURL.
+	InstantSiteBaseURL string `json:"instant_site_base_url,omitempty" yaml:"instant_site_base_url,omitempty" mapstructure:"instant_site_base_url"`
+
+	// InstantSiteAuthURL is the base URL for the Instant Site OAuth token
+	// exchange. Defaults to DefaultInstantSiteAuthURL.
+	InstantSiteAuthURL string `json:"instant_site_auth_url,omitempty" yaml:"instant_site_auth_url,omitempty" mapstructure:"instant_site_auth_url"`
+
+	// InstantSiteToken is the separate access token for the Instant Site v1 API,
+	// obtained via the token-exchange endpoint (24h lifetime). Empty by default;
+	// v1 Instant Site calls require it.
+	InstantSiteToken string `json:"instant_site_token,omitempty" yaml:"instant_site_token,omitempty" mapstructure:"instant_site_token"`
 }
 
 // Validate checks that required fields are present and values are valid.
@@ -82,7 +108,25 @@ func (c Config) WithDefaults() Config {
 	if c.LogLevel == "" {
 		c.LogLevel = DefaultLogLevel
 	}
+	if c.InstantSiteBaseURL == "" {
+		c.InstantSiteBaseURL = DefaultInstantSiteBaseURL
+	}
+	if c.InstantSiteAuthURL == "" {
+		c.InstantSiteAuthURL = DefaultInstantSiteAuthURL
+	}
 	return c
+}
+
+// RedactedInstantSiteToken returns the Instant Site token with all but the last
+// 4 characters masked. Use this for logging — never log the full token.
+func (c *Config) RedactedInstantSiteToken() string {
+	if c.InstantSiteToken == "" {
+		return ""
+	}
+	if len(c.InstantSiteToken) <= 4 {
+		return "****"
+	}
+	return strings.Repeat("*", len(c.InstantSiteToken)-4) + c.InstantSiteToken[len(c.InstantSiteToken)-4:]
 }
 
 // RedactedToken returns the token with all but the last 4 characters masked.
@@ -94,15 +138,17 @@ func (c *Config) RedactedToken() string {
 	return strings.Repeat("*", len(c.Token)-4) + c.Token[len(c.Token)-4:]
 }
 
-// MarshalJSON implements custom JSON marshaling that redacts the token.
+// MarshalJSON implements custom JSON marshaling that redacts secret tokens.
 func (c Config) MarshalJSON() ([]byte, error) {
 	type alias Config
 	safe := struct {
 		alias
-		Token string `json:"token"`
+		Token            string `json:"token"`
+		InstantSiteToken string `json:"instant_site_token,omitempty"`
 	}{
-		alias: alias(c),
-		Token: c.RedactedToken(),
+		alias:            alias(c),
+		Token:            c.RedactedToken(),
+		InstantSiteToken: c.RedactedInstantSiteToken(),
 	}
 	return json.Marshal(safe)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -79,9 +79,12 @@ func TestMain(m *testing.M) {
 
 	// Set up API client if credentials are available.
 	cfg := config.Config{
-		StoreID:    os.Getenv("ECWID_STORE_ID"),
-		Token:      os.Getenv("ECWID_TOKEN"),
-		MaxRetries: 3,
+		StoreID:            os.Getenv("ECWID_STORE_ID"),
+		Token:              os.Getenv("ECWID_TOKEN"),
+		MaxRetries:         3,
+		InstantSiteBaseURL: os.Getenv("ECWID_INSTANT_SITE_BASE_URL"),
+		InstantSiteAuthURL: os.Getenv("ECWID_INSTANT_SITE_AUTH_URL"),
+		InstantSiteToken:   os.Getenv("ECWID_INSTANT_SITE_TOKEN"),
 	}
 	cfg = cfg.WithDefaults()
 

--- a/e2e/instantsite_test.go
+++ b/e2e/instantsite_test.go
@@ -1,0 +1,70 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+// requireInstantSiteToken skips a test that hits the Instant Site v1 host when no
+// Instant Site token is configured (the v1 endpoints use a separate 24h token).
+func requireInstantSiteToken(t *testing.T) {
+	t.Helper()
+	if os.Getenv("ECWID_INSTANT_SITE_TOKEN") == "" {
+		t.Skip("skipping: ECWID_INSTANT_SITE_TOKEN required for Instant Site v1 endpoints")
+	}
+}
+
+// Redirects live on the main API host and use the main token, so they only need
+// the manage_instant_site scope (skipIfForbidden covers a missing scope).
+func TestInstantSite_SearchRedirects(t *testing.T) {
+	requireClient(t)
+	ctx := testContext(t)
+
+	result, err := testClient.InstantSite.SearchRedirects(ctx, nil)
+	if err != nil {
+		skipIfForbidden(t, err)
+		t.Fatalf("InstantSite.SearchRedirects: %v", err)
+	}
+	t.Logf("found %d redirects", result.Total)
+}
+
+func TestInstantSite_GetProfile(t *testing.T) {
+	requireClient(t)
+	requireInstantSiteToken(t)
+	ctx := testContext(t)
+
+	profile, err := testClient.InstantSite.GetProfile(ctx)
+	if err != nil {
+		skipIfForbidden(t, err)
+		t.Fatalf("InstantSite.GetProfile: %v", err)
+	}
+	if profile.SiteURL == "" {
+		t.Log("profile returned without a siteUrl")
+	}
+}
+
+func TestInstantSite_ListPages(t *testing.T) {
+	requireClient(t)
+	requireInstantSiteToken(t)
+	ctx := testContext(t)
+
+	result, err := testClient.InstantSite.ListPages(ctx, true)
+	if err != nil {
+		skipIfForbidden(t, err)
+		t.Fatalf("InstantSite.ListPages: %v", err)
+	}
+	t.Logf("found %d published pages", len(result.Pages))
+}
+
+func TestInstantSite_ListThemes(t *testing.T) {
+	requireClient(t)
+	requireInstantSiteToken(t)
+	ctx := testContext(t)
+
+	result, err := testClient.InstantSite.ListThemes(ctx)
+	if err != nil {
+		skipIfForbidden(t, err)
+		t.Fatalf("InstantSite.ListThemes: %v", err)
+	}
+	t.Logf("found %d themes", len(result.Themes))
+}

--- a/ecwid/client.go
+++ b/ecwid/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/matthiasbruns/ecwid-go/ecwid/dictionaries"
 	"github.com/matthiasbruns/ecwid-go/ecwid/discounts"
 	"github.com/matthiasbruns/ecwid-go/ecwid/domains"
+	"github.com/matthiasbruns/ecwid-go/ecwid/instantsite"
 	"github.com/matthiasbruns/ecwid-go/ecwid/internal/api"
 	"github.com/matthiasbruns/ecwid-go/ecwid/orders"
 	"github.com/matthiasbruns/ecwid-go/ecwid/products"
@@ -38,6 +39,7 @@ type Client struct {
 	Dictionaries  *dictionaries.Service
 	Discounts     *discounts.Service
 	Domains       *domains.Service
+	InstantSite   *instantsite.Service
 	Orders        *orders.Service
 	Products      *products.Service
 	Profile       *profile.Service
@@ -97,6 +99,26 @@ func NewClient(cfg config.Config, opts ...Option) *Client {
 		Logger:     o.logger,
 	})
 
+	// The Instant Site v1 endpoints live on a separate host and use a separate
+	// token; the token-exchange endpoint uses the auth host with no store-ID
+	// path segment and no bearer token.
+	instantSiteV1 := api.NewHTTPClient(api.HTTPClientConfig{
+		BaseURL:    cfg.InstantSiteBaseURL,
+		StoreID:    cfg.StoreID,
+		Token:      cfg.InstantSiteToken,
+		MaxRetries: cfg.MaxRetries,
+		HTTPClient: o.httpClient,
+		Logger:     o.logger,
+	})
+	instantSiteAuth := api.NewHTTPClient(api.HTTPClientConfig{
+		BaseURL:    cfg.InstantSiteAuthURL,
+		StoreID:    "",
+		Token:      "",
+		MaxRetries: cfg.MaxRetries,
+		HTTPClient: o.httpClient,
+		Logger:     o.logger,
+	})
+
 	return &Client{
 		Billing:       billing.NewService(requester),
 		Carts:         carts.NewService(requester),
@@ -105,6 +127,7 @@ func NewClient(cfg config.Config, opts ...Option) *Client {
 		Dictionaries:  dictionaries.NewService(requester),
 		Discounts:     discounts.NewService(requester),
 		Domains:       domains.NewService(requester),
+		InstantSite:   instantsite.NewService(requester, instantSiteV1, instantSiteAuth),
 		Orders:        orders.NewService(requester),
 		Products:      products.NewService(requester),
 		Profile:       profile.NewService(requester),

--- a/ecwid/instantsite/service.go
+++ b/ecwid/instantsite/service.go
@@ -1,0 +1,563 @@
+package instantsite
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/internal/api"
+)
+
+// Service provides access to the Ecwid Instant Site API.
+//
+// It routes calls across three requesters because the Instant Site API spans
+// two hosts and two tokens (see the package doc): the redirect endpoints use the
+// main API host + main token; the v1 endpoints use the Instant Site host + the
+// Instant Site token; the token-exchange endpoint uses the auth host.
+type Service struct {
+	main api.Requester // app.ecwid.com/api/v3 — redirects (main token)
+	v1   api.Requester // vuega.ecwid.com/api/v1 — profile/pages/tiles/themes/… (instant-site token)
+	auth api.Requester // app.ecwid.com/instantsite — token exchange
+}
+
+// NewService creates a new Instant Site service. The main requester serves the
+// v3 redirect endpoints, v1 serves the Instant Site v1 endpoints, and auth
+// serves the token-exchange endpoint.
+func NewService(main, v1, auth api.Requester) *Service {
+	return &Service{main: main, v1: v1, auth: auth}
+}
+
+// ── Token exchange ──────────────────────────────────────────────────────────
+
+// Token exchanges an app secret token for a short-lived (24h) Instant Site
+// access token. Store the returned token in config (InstantSiteToken) to build a
+// client that can call the v1 Instant Site endpoints.
+//
+// API: POST /oauth/token
+// Required scope: manage_instant_site
+func (s *Service) Token(ctx context.Context, req *TokenRequest) (*TokenResult, error) {
+	if req == nil {
+		return nil, errors.New("token request must not be nil")
+	}
+	if req.SiteID == "" {
+		return nil, errors.New("token request SiteID must not be empty")
+	}
+	if req.Code == "" {
+		return nil, errors.New("token request Code must not be empty")
+	}
+
+	grantType := req.GrantType
+	if grantType == "" {
+		grantType = GrantTypeAuthorizationCode
+	}
+
+	q := url.Values{}
+	q.Set("grant_type", grantType)
+	q.Set("site_id", req.SiteID)
+	q.Set("code", req.Code)
+
+	var result TokenResult
+	// The auth requester is built with an empty store ID, so its base URL ends
+	// with a slash; the path here is intentionally slash-less.
+	if err := s.auth.Post(ctx, "oauth/token?"+q.Encode(), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ── Profile ─────────────────────────────────────────────────────────────────
+
+// GetProfile returns the Instant Site profile.
+//
+// API: GET /profile
+// Required scope: manage_instant_site
+func (s *Service) GetProfile(ctx context.Context) (*Profile, error) {
+	var result Profile
+	if err := s.v1.Get(ctx, "/profile", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateProfile creates the Instant Site profile.
+//
+// API: POST /profile
+// Required scope: manage_instant_site
+func (s *Service) CreateProfile(ctx context.Context, profile *Profile) (*Profile, error) {
+	var result Profile
+	if err := s.v1.Post(ctx, "/profile", profile, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateProfile updates the Instant Site profile.
+//
+// API: PUT /profile
+// Required scope: manage_instant_site
+func (s *Service) UpdateProfile(ctx context.Context, profile *Profile) (*Profile, error) {
+	var result Profile
+	if err := s.v1.Put(ctx, "/profile", profile, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+// Publish publishes the current Instant Site draft.
+//
+// API: POST /publish
+// Required scope: manage_instant_site
+func (s *Service) Publish(ctx context.Context) error {
+	return s.v1.Post(ctx, "/publish", struct{}{}, nil)
+}
+
+// Discard discards unpublished Instant Site draft changes.
+//
+// API: POST /discard
+// Required scope: manage_instant_site
+func (s *Service) Discard(ctx context.Context) error {
+	return s.v1.Post(ctx, "/discard", struct{}{}, nil)
+}
+
+// Clone clones an Instant Site from another store.
+//
+// API: POST /clone
+// Required scopes: manage_instant_site, clone_stores
+func (s *Service) Clone(ctx context.Context, req *CloneRequest) error {
+	if req == nil {
+		return errors.New("clone request must not be nil")
+	}
+	return s.v1.Post(ctx, "/clone", req, nil)
+}
+
+// ── Pages ───────────────────────────────────────────────────────────────────
+
+// ListPages returns the Instant Site pages. Set published to true for the
+// published site or false for the draft.
+//
+// API: GET /page?published={published}
+// Required scope: manage_instant_site
+func (s *Service) ListPages(ctx context.Context, published bool) (*PageList, error) {
+	q := url.Values{}
+	q.Set("published", fmt.Sprintf("%t", published))
+
+	var result PageList
+	if err := s.v1.Get(ctx, "/page", q, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreatePage creates a new Instant Site page.
+//
+// API: POST /page
+// Required scope: manage_instant_site
+func (s *Service) CreatePage(ctx context.Context, page *Page) (*CreatePageResult, error) {
+	var result CreatePageResult
+	if err := s.v1.Post(ctx, "/page", page, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdatePage updates an Instant Site page.
+//
+// API: PUT /page/{pageId}
+// Required scope: manage_instant_site
+func (s *Service) UpdatePage(ctx context.Context, pageID string, page *Page) (*Page, error) {
+	if pageID == "" {
+		return nil, errors.New("pageID must not be empty")
+	}
+	path := fmt.Sprintf("/page/%s", pageID)
+
+	var result Page
+	if err := s.v1.Put(ctx, path, page, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeletePage deletes an Instant Site page and returns the deleted page.
+//
+// API: DELETE /page/{pageId}
+// Required scope: manage_instant_site
+func (s *Service) DeletePage(ctx context.Context, pageID string) (*Page, error) {
+	if pageID == "" {
+		return nil, errors.New("pageID must not be empty")
+	}
+	path := fmt.Sprintf("/page/%s", pageID)
+
+	var result Page
+	if err := s.v1.Delete(ctx, path, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ── Tiles ───────────────────────────────────────────────────────────────────
+
+// ListTiles returns Instant Site tiles, optionally filtered by page and
+// language.
+//
+// API: GET /tile?published={published}
+// Required scope: manage_instant_site
+func (s *Service) ListTiles(ctx context.Context, opts *TileListOptions) (*TileList, error) {
+	q := url.Values{}
+	if opts != nil {
+		q.Set("published", fmt.Sprintf("%t", opts.Published))
+		if opts.PageID != "" {
+			q.Set("pageId", opts.PageID)
+		}
+		if opts.Lang != "" {
+			q.Set("lang", opts.Lang)
+		}
+	} else {
+		q.Set("published", "false")
+	}
+
+	var result TileList
+	if err := s.v1.Get(ctx, "/tile", q, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetTile returns a single Instant Site tile by ID.
+//
+// API: GET /tile/{tileId}
+// Required scope: manage_instant_site
+func (s *Service) GetTile(ctx context.Context, tileID string) (*Tile, error) {
+	if tileID == "" {
+		return nil, errors.New("tileID must not be empty")
+	}
+	path := fmt.Sprintf("/tile/%s", tileID)
+
+	var result Tile
+	if err := s.v1.Get(ctx, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateTile creates a new Instant Site tile.
+//
+// API: POST /tile
+// Required scope: manage_instant_site
+func (s *Service) CreateTile(ctx context.Context, req *CreateTileRequest) (*Tile, error) {
+	var result Tile
+	if err := s.v1.Post(ctx, "/tile", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateTile updates a single Instant Site tile.
+//
+// API: PUT /tile/{tileId}
+// Required scope: manage_instant_site
+func (s *Service) UpdateTile(ctx context.Context, tileID string, tile *TileUpdate) (*Tile, error) {
+	if tileID == "" {
+		return nil, errors.New("tileID must not be empty")
+	}
+	path := fmt.Sprintf("/tile/%s", tileID)
+
+	var result Tile
+	if err := s.v1.Put(ctx, path, tile, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateTiles updates the whole tiles list in one request.
+//
+// API: PUT /tile
+// Required scope: manage_instant_site
+func (s *Service) UpdateTiles(ctx context.Context, tiles *TileBulkUpdate) (*TileList, error) {
+	var result TileList
+	if err := s.v1.Put(ctx, "/tile", tiles, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteTile deletes an Instant Site tile, removing it from every page it was
+// on.
+//
+// API: DELETE /tile/{tileId}
+// Required scope: manage_instant_site
+func (s *Service) DeleteTile(ctx context.Context, tileID string) (*Tile, error) {
+	if tileID == "" {
+		return nil, errors.New("tileID must not be empty")
+	}
+	path := fmt.Sprintf("/tile/%s", tileID)
+
+	var result Tile
+	if err := s.v1.Delete(ctx, path, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// TileShowcase returns the available tile templates grouped by category.
+//
+// API: GET /tile/showcase
+// Required scope: manage_instant_site
+func (s *Service) TileShowcase(ctx context.Context) (*TileShowcaseResult, error) {
+	var result TileShowcaseResult
+	if err := s.v1.Get(ctx, "/tile/showcase", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// TileConfig returns the content/design editor config for a tile category type.
+//
+// API: GET /tile/config/{configType}
+// Required scope: manage_instant_site
+func (s *Service) TileConfig(ctx context.Context, configType string) (*TileConfigResult, error) {
+	if configType == "" {
+		return nil, errors.New("configType must not be empty")
+	}
+	path := fmt.Sprintf("/tile/config/%s", configType)
+
+	var result TileConfigResult
+	if err := s.v1.Get(ctx, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ── Tile images ─────────────────────────────────────────────────────────────
+
+// ReserveTileImage reserves an upload slot for a tile image. Upload the image
+// binary as multipart/form-data to the returned URL.
+//
+// API: POST /tile/{tileId}/image
+// Required scope: manage_instant_site
+func (s *Service) ReserveTileImage(ctx context.Context, tileID string) (*ReserveImageResult, error) {
+	if tileID == "" {
+		return nil, errors.New("tileID must not be empty")
+	}
+	path := fmt.Sprintf("/tile/%s/image", tileID)
+
+	var result ReserveImageResult
+	if err := s.v1.Post(ctx, path, struct{}{}, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetImage returns the rendered result of an uploaded tile image.
+//
+// API: GET /image/{imageId}
+// Required scope: manage_instant_site
+func (s *Service) GetImage(ctx context.Context, imageID string) (*ImageResult, error) {
+	if imageID == "" {
+		return nil, errors.New("imageID must not be empty")
+	}
+	path := fmt.Sprintf("/image/%s", imageID)
+
+	var result ImageResult
+	if err := s.v1.Get(ctx, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ImageBuckets returns the map of image bucket IDs to their CDN base URLs.
+//
+// API: GET /image/bucket
+// Required scope: manage_instant_site
+func (s *Service) ImageBuckets(ctx context.Context) (*ImageBucketsResult, error) {
+	var result ImageBucketsResult
+	if err := s.v1.Get(ctx, "/image/bucket", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ── Themes ──────────────────────────────────────────────────────────────────
+
+// ListThemes returns the store's saved Instant Site themes.
+//
+// API: GET /themes
+// Required scope: manage_instant_site
+func (s *Service) ListThemes(ctx context.Context) (*ThemeList, error) {
+	var result ThemeList
+	if err := s.v1.Get(ctx, "/themes", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateTheme creates a new Instant Site theme from a color palette.
+//
+// API: POST /themes
+// Required scope: manage_instant_site
+func (s *Service) CreateTheme(ctx context.Context, colors *ThemeColors) (*Theme, error) {
+	var result Theme
+	if err := s.v1.Post(ctx, "/themes", themeBody(colors), &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateTheme updates an existing Instant Site theme.
+//
+// API: PUT /themes/{themeId}
+// Required scope: manage_instant_site
+func (s *Service) UpdateTheme(ctx context.Context, themeID string, colors *ThemeColors) (*Theme, error) {
+	if themeID == "" {
+		return nil, errors.New("themeID must not be empty")
+	}
+	path := fmt.Sprintf("/themes/%s", themeID)
+
+	var result Theme
+	if err := s.v1.Put(ctx, path, themeBody(colors), &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteTheme deletes an Instant Site theme and returns the deleted theme.
+//
+// API: DELETE /themes/{themeId}
+// Required scope: manage_instant_site
+func (s *Service) DeleteTheme(ctx context.Context, themeID string) (*Theme, error) {
+	if themeID == "" {
+		return nil, errors.New("themeID must not be empty")
+	}
+	path := fmt.Sprintf("/themes/%s", themeID)
+
+	var result Theme
+	if err := s.v1.Delete(ctx, path, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CurrentTheme returns the store's currently applied theme palette.
+//
+// API: GET /current_theme
+// Required scope: manage_instant_site
+func (s *Service) CurrentTheme(ctx context.Context) (*CurrentTheme, error) {
+	var result CurrentTheme
+	if err := s.v1.Get(ctx, "/current_theme", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateCurrentTheme sets the store's currently applied theme palette.
+//
+// API: PUT /current_theme
+// Required scope: manage_instant_site
+func (s *Service) UpdateCurrentTheme(ctx context.Context, colors *ThemeColors) (*Theme, error) {
+	var result Theme
+	if err := s.v1.Put(ctx, "/current_theme", themeBody(colors), &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// themeBody wraps a color palette in the {"colors": …} request envelope the
+// theme endpoints expect.
+func themeBody(colors *ThemeColors) any {
+	var c ThemeColors
+	if colors != nil {
+		c = *colors
+	}
+	return struct {
+		Colors ThemeColors `json:"colors"`
+	}{Colors: c}
+}
+
+// ── Text labels ─────────────────────────────────────────────────────────────
+
+// TextLabels returns the Instant Site text labels (i18n translations).
+//
+// API: GET /translation
+// Required scope: manage_instant_site
+func (s *Service) TextLabels(ctx context.Context) (*TextLabels, error) {
+	var result TextLabels
+	if err := s.v1.Get(ctx, "/translation", nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// ── Redirects (v3, main requester) ──────────────────────────────────────────
+
+// SearchRedirects returns a paginated list of 301 URL redirects.
+//
+// API: GET /instant-site/redirects
+// Required scope: manage_instant_site
+func (s *Service) SearchRedirects(ctx context.Context, opts *RedirectSearchOptions) (*RedirectSearchResult, error) {
+	q := url.Values{}
+	if opts != nil {
+		if opts.Keyword != "" {
+			q.Set("keyword", opts.Keyword)
+		}
+		if opts.Offset > 0 {
+			q.Set("offset", fmt.Sprintf("%d", opts.Offset))
+		}
+		if opts.Limit > 0 {
+			q.Set("limit", fmt.Sprintf("%d", opts.Limit))
+		}
+	}
+
+	var result RedirectSearchResult
+	if err := s.main.Get(ctx, "/instant-site/redirects", q, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetRedirect returns a single redirect by ID.
+//
+// API: GET /instant-site/redirects/{redirectId}
+// Required scope: manage_instant_site
+func (s *Service) GetRedirect(ctx context.Context, redirectID string) (*Redirect, error) {
+	if redirectID == "" {
+		return nil, errors.New("redirectID must not be empty")
+	}
+	path := fmt.Sprintf("/instant-site/redirects/%s", redirectID)
+
+	var result Redirect
+	if err := s.main.Get(ctx, path, nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateRedirect creates a new 301 URL redirect.
+//
+// API: POST /instant-site/redirects
+// Required scope: manage_instant_site
+func (s *Service) CreateRedirect(ctx context.Context, redirect *Redirect) (*Redirect, error) {
+	var result Redirect
+	if err := s.main.Post(ctx, "/instant-site/redirects", redirect, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpdateRedirect updates an existing 301 URL redirect.
+//
+// API: PUT /instant-site/redirects/{redirectId}
+// Required scope: manage_instant_site
+func (s *Service) UpdateRedirect(ctx context.Context, redirectID string, redirect *Redirect) (*Redirect, error) {
+	if redirectID == "" {
+		return nil, errors.New("redirectID must not be empty")
+	}
+	path := fmt.Sprintf("/instant-site/redirects/%s", redirectID)
+
+	var result Redirect
+	if err := s.main.Put(ctx, path, redirect, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/ecwid/instantsite/service.go
+++ b/ecwid/instantsite/service.go
@@ -171,7 +171,7 @@ func (s *Service) UpdatePage(ctx context.Context, pageID string, page *Page) (*P
 	if pageID == "" {
 		return nil, errors.New("pageID must not be empty")
 	}
-	path := fmt.Sprintf("/page/%s", pageID)
+	path := "/page/" + url.PathEscape(pageID)
 
 	var result Page
 	if err := s.v1.Put(ctx, path, page, &result); err != nil {
@@ -188,7 +188,7 @@ func (s *Service) DeletePage(ctx context.Context, pageID string) (*Page, error) 
 	if pageID == "" {
 		return nil, errors.New("pageID must not be empty")
 	}
-	path := fmt.Sprintf("/page/%s", pageID)
+	path := "/page/" + url.PathEscape(pageID)
 
 	var result Page
 	if err := s.v1.Delete(ctx, path, &result); err != nil {
@@ -233,7 +233,7 @@ func (s *Service) GetTile(ctx context.Context, tileID string) (*Tile, error) {
 	if tileID == "" {
 		return nil, errors.New("tileID must not be empty")
 	}
-	path := fmt.Sprintf("/tile/%s", tileID)
+	path := "/tile/" + url.PathEscape(tileID)
 
 	var result Tile
 	if err := s.v1.Get(ctx, path, nil, &result); err != nil {
@@ -262,7 +262,7 @@ func (s *Service) UpdateTile(ctx context.Context, tileID string, tile *TileUpdat
 	if tileID == "" {
 		return nil, errors.New("tileID must not be empty")
 	}
-	path := fmt.Sprintf("/tile/%s", tileID)
+	path := "/tile/" + url.PathEscape(tileID)
 
 	var result Tile
 	if err := s.v1.Put(ctx, path, tile, &result); err != nil {
@@ -292,7 +292,7 @@ func (s *Service) DeleteTile(ctx context.Context, tileID string) (*Tile, error) 
 	if tileID == "" {
 		return nil, errors.New("tileID must not be empty")
 	}
-	path := fmt.Sprintf("/tile/%s", tileID)
+	path := "/tile/" + url.PathEscape(tileID)
 
 	var result Tile
 	if err := s.v1.Delete(ctx, path, &result); err != nil {
@@ -321,7 +321,7 @@ func (s *Service) TileConfig(ctx context.Context, configType string) (*TileConfi
 	if configType == "" {
 		return nil, errors.New("configType must not be empty")
 	}
-	path := fmt.Sprintf("/tile/config/%s", configType)
+	path := "/tile/config/" + url.PathEscape(configType)
 
 	var result TileConfigResult
 	if err := s.v1.Get(ctx, path, nil, &result); err != nil {
@@ -341,7 +341,7 @@ func (s *Service) ReserveTileImage(ctx context.Context, tileID string) (*Reserve
 	if tileID == "" {
 		return nil, errors.New("tileID must not be empty")
 	}
-	path := fmt.Sprintf("/tile/%s/image", tileID)
+	path := "/tile/" + url.PathEscape(tileID) + "/image"
 
 	var result ReserveImageResult
 	if err := s.v1.Post(ctx, path, struct{}{}, &result); err != nil {
@@ -358,7 +358,7 @@ func (s *Service) GetImage(ctx context.Context, imageID string) (*ImageResult, e
 	if imageID == "" {
 		return nil, errors.New("imageID must not be empty")
 	}
-	path := fmt.Sprintf("/image/%s", imageID)
+	path := "/image/" + url.PathEscape(imageID)
 
 	var result ImageResult
 	if err := s.v1.Get(ctx, path, nil, &result); err != nil {
@@ -413,7 +413,7 @@ func (s *Service) UpdateTheme(ctx context.Context, themeID string, colors *Theme
 	if themeID == "" {
 		return nil, errors.New("themeID must not be empty")
 	}
-	path := fmt.Sprintf("/themes/%s", themeID)
+	path := "/themes/" + url.PathEscape(themeID)
 
 	var result Theme
 	if err := s.v1.Put(ctx, path, themeBody(colors), &result); err != nil {
@@ -430,7 +430,7 @@ func (s *Service) DeleteTheme(ctx context.Context, themeID string) (*Theme, erro
 	if themeID == "" {
 		return nil, errors.New("themeID must not be empty")
 	}
-	path := fmt.Sprintf("/themes/%s", themeID)
+	path := "/themes/" + url.PathEscape(themeID)
 
 	var result Theme
 	if err := s.v1.Delete(ctx, path, &result); err != nil {
@@ -524,7 +524,7 @@ func (s *Service) GetRedirect(ctx context.Context, redirectID string) (*Redirect
 	if redirectID == "" {
 		return nil, errors.New("redirectID must not be empty")
 	}
-	path := fmt.Sprintf("/instant-site/redirects/%s", redirectID)
+	path := "/instant-site/redirects/" + url.PathEscape(redirectID)
 
 	var result Redirect
 	if err := s.main.Get(ctx, path, nil, &result); err != nil {
@@ -553,7 +553,7 @@ func (s *Service) UpdateRedirect(ctx context.Context, redirectID string, redirec
 	if redirectID == "" {
 		return nil, errors.New("redirectID must not be empty")
 	}
-	path := fmt.Sprintf("/instant-site/redirects/%s", redirectID)
+	path := "/instant-site/redirects/" + url.PathEscape(redirectID)
 
 	var result Redirect
 	if err := s.main.Put(ctx, path, redirect, &result); err != nil {

--- a/ecwid/instantsite/service_test.go
+++ b/ecwid/instantsite/service_test.go
@@ -1,0 +1,833 @@
+package instantsite_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/instantsite"
+	"github.com/matthiasbruns/ecwid-go/ecwid/internal/api"
+)
+
+// newTestService builds a Service whose three requesters all point at the single
+// test server, using distinct base-URL prefixes so the v3 (main), v1, and auth
+// hosts don't collide on one mux:
+//
+//	main → /api/v3/12345/…
+//	v1   → /api/v1/12345/…
+//	auth → /instantsite/… (no store-ID segment)
+func newTestService(t *testing.T, srv *httptest.Server) *instantsite.Service {
+	t.Helper()
+	main := api.NewHTTPClient(api.HTTPClientConfig{
+		BaseURL: srv.URL + "/api/v3",
+		StoreID: "12345",
+		Token:   "secret_test",
+	})
+	v1 := api.NewHTTPClient(api.HTTPClientConfig{
+		BaseURL: srv.URL + "/api/v1",
+		StoreID: "12345",
+		Token:   "is_test",
+	})
+	auth := api.NewHTTPClient(api.HTTPClientConfig{
+		BaseURL: srv.URL + "/instantsite",
+		StoreID: "",
+		Token:   "",
+	})
+	return instantsite.NewService(main, v1, auth)
+}
+
+// ── Token ─────────────────────────────────────────────────────────────────
+
+func TestToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/instantsite/oauth/token" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		q := r.URL.Query()
+		if q.Get("grant_type") != "authorization_code" {
+			t.Errorf("expected grant_type=authorization_code, got %s", q.Get("grant_type"))
+		}
+		if q.Get("site_id") != "12345" {
+			t.Errorf("expected site_id=12345, got %s", q.Get("site_id"))
+		}
+		if q.Get("code") != "app_secret" {
+			t.Errorf("expected code=app_secret, got %s", q.Get("code"))
+		}
+		// The auth requester carries no bearer token.
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("expected no Authorization header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"accessToken":"tok_abc","tokenType":"bearer","expiresIn":86400}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.Token(context.Background(), &instantsite.TokenRequest{SiteID: "12345", Code: "app_secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.AccessToken != "tok_abc" {
+		t.Errorf("expected accessToken=tok_abc, got %s", result.AccessToken)
+	}
+	if result.ExpiresIn != 86400 {
+		t.Errorf("expected expiresIn=86400, got %d", result.ExpiresIn)
+	}
+}
+
+func TestToken_Guards(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("should not reach server")
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	if _, err := svc.Token(context.Background(), nil); err == nil {
+		t.Error("expected error for nil request")
+	}
+	if _, err := svc.Token(context.Background(), &instantsite.TokenRequest{Code: "x"}); err == nil {
+		t.Error("expected error for empty SiteID")
+	}
+	if _, err := svc.Token(context.Background(), &instantsite.TokenRequest{SiteID: "12345"}); err == nil {
+		t.Error("expected error for empty Code")
+	}
+}
+
+// ── Profile ───────────────────────────────────────────────────────────────
+
+func TestGetProfile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/12345/profile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer is_test" {
+			t.Errorf("expected instant-site bearer token, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"siteId":"s1","storeName":"My Store","ecwidApiUrl":"https://vuega.ecwid.com/api/v1"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	p, err := svc.GetProfile(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.StoreName != "My Store" {
+		t.Errorf("expected storeName=My Store, got %s", p.StoreName)
+	}
+	if p.EcwidAPIURL != "https://vuega.ecwid.com/api/v1" {
+		t.Errorf("unexpected ecwidApiUrl: %s", p.EcwidAPIURL)
+	}
+}
+
+func TestCreateProfile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/12345/profile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"storeName":"New Store"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	p, err := svc.CreateProfile(context.Background(), &instantsite.Profile{StoreName: "New Store"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.StoreName != "New Store" {
+		t.Errorf("expected storeName=New Store, got %s", p.StoreName)
+	}
+}
+
+func TestUpdateProfile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"storeName":"Updated"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	p, err := svc.UpdateProfile(context.Background(), &instantsite.Profile{StoreName: "Updated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.StoreName != "Updated" {
+		t.Errorf("expected storeName=Updated, got %s", p.StoreName)
+	}
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────
+
+func TestPublishDiscard(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*instantsite.Service) error
+		path string
+	}{
+		{"publish", func(s *instantsite.Service) error { return s.Publish(context.Background()) }, "/api/v1/12345/publish"},
+		{"discard", func(s *instantsite.Service) error { return s.Discard(context.Background()) }, "/api/v1/12345/discard"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("expected POST, got %s", r.Method)
+				}
+				if r.URL.Path != tc.path {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer srv.Close()
+
+			if err := tc.call(newTestService(t, srv)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestClone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/12345/clone" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"source":99`) {
+			t.Errorf("expected source=99 in body, got %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	if err := svc.Clone(context.Background(), &instantsite.CloneRequest{Source: 99, Draft: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Clone(context.Background(), nil); err == nil {
+		t.Error("expected error for nil clone request")
+	}
+}
+
+// ── Pages ─────────────────────────────────────────────────────────────────
+
+func TestListPages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/12345/page" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("published") != "true" {
+			t.Errorf("expected published=true, got %s", r.URL.Query().Get("published"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pages":[{"pageId":"p1","title":"Home","tileIds":["t1","t2"]}]}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.ListPages(context.Background(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Pages) != 1 || result.Pages[0].Title != "Home" {
+		t.Errorf("unexpected pages: %+v", result.Pages)
+	}
+	if len(result.Pages[0].TileIDs) != 2 {
+		t.Errorf("expected 2 tileIds, got %d", len(result.Pages[0].TileIDs))
+	}
+}
+
+func TestCreatePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pageId":"p9"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.CreatePage(context.Background(), &instantsite.Page{Title: "New"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PageID != "p9" {
+		t.Errorf("expected pageId=p9, got %s", result.PageID)
+	}
+}
+
+func TestUpdatePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/12345/page/p1" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pageId":"p1","title":"Renamed"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.UpdatePage(context.Background(), "p1", &instantsite.Page{Title: "Renamed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Title != "Renamed" {
+		t.Errorf("expected title=Renamed, got %s", result.Title)
+	}
+}
+
+func TestPage_EmptyIDGuards(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("should not reach server")
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	if _, err := svc.UpdatePage(context.Background(), "", &instantsite.Page{}); err == nil {
+		t.Error("expected error for empty pageID on update")
+	}
+	if _, err := svc.DeletePage(context.Background(), ""); err == nil {
+		t.Error("expected error for empty pageID on delete")
+	}
+}
+
+func TestDeletePage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/12345/page/p1" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"pageId":"p1"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.DeletePage(context.Background(), "p1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.PageID != "p1" {
+		t.Errorf("expected pageId=p1, got %s", result.PageID)
+	}
+}
+
+// ── Tiles ─────────────────────────────────────────────────────────────────
+
+func TestListTiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/12345/tile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("published") != "true" {
+			t.Errorf("expected published=true, got %s", q.Get("published"))
+		}
+		if q.Get("pageId") != "p1" {
+			t.Errorf("expected pageId=p1, got %s", q.Get("pageId"))
+		}
+		if q.Get("lang") != "en" {
+			t.Errorf("expected lang=en, got %s", q.Get("lang"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tiles":[{"id":"t1","type":"COVER","content":{"title":"Hi"}}]}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.ListTiles(context.Background(), &instantsite.TileListOptions{Published: true, PageID: "p1", Lang: "en"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Tiles) != 1 || result.Tiles[0].Type != "COVER" {
+		t.Errorf("unexpected tiles: %+v", result.Tiles)
+	}
+	if result.Tiles[0].Content == nil {
+		t.Error("expected opaque content to be preserved")
+	}
+}
+
+func TestListTiles_NilOptions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("published") != "false" {
+			t.Errorf("expected published=false default, got %s", r.URL.Query().Get("published"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tiles":[]}`))
+	}))
+	defer srv.Close()
+
+	if _, err := newTestService(t, srv).ListTiles(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetTile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/12345/tile/t1" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"t1","type":"HEADER"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	tile, err := svc.GetTile(context.Background(), "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tile.Type != "HEADER" {
+		t.Errorf("expected type=HEADER, got %s", tile.Type)
+	}
+}
+
+func TestCreateTile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v1/12345/tile" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"tileCategoryType":"COVER"`) {
+			t.Errorf("expected tileCategoryType in body, got %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"t9","type":"COVER"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	tile, err := svc.CreateTile(context.Background(), &instantsite.CreateTileRequest{
+		TileCategoryType: "COVER",
+		Tile:             &instantsite.TileCreateBody{Type: "COVER"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tile.ID != "t9" {
+		t.Errorf("expected id=t9, got %s", tile.ID)
+	}
+}
+
+func TestUpdateTile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/12345/tile/t1" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"t1","tileName":"Renamed"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	tile, err := svc.UpdateTile(context.Background(), "t1", &instantsite.TileUpdate{TileName: "Renamed", Visibility: boolPtr(false)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tile.TileName != "Renamed" {
+		t.Errorf("expected tileName=Renamed, got %s", tile.TileName)
+	}
+}
+
+func TestUpdateTiles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/api/v1/12345/tile" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tiles":[{"id":"t1"},{"id":"t2"}]}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.UpdateTiles(context.Background(), &instantsite.TileBulkUpdate{
+		Tiles: []instantsite.TileUpdate{{ID: "t1"}, {ID: "t2"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Tiles) != 2 {
+		t.Errorf("expected 2 tiles, got %d", len(result.Tiles))
+	}
+}
+
+func TestDeleteTile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/v1/12345/tile/t1" {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"t1"}`))
+	}))
+	defer srv.Close()
+
+	if _, err := newTestService(t, srv).DeleteTile(context.Background(), "t1"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTile_EmptyIDGuards(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("should not reach server")
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	if _, err := svc.GetTile(context.Background(), ""); err == nil {
+		t.Error("expected error for empty tileID on get")
+	}
+	if _, err := svc.UpdateTile(context.Background(), "", &instantsite.TileUpdate{}); err == nil {
+		t.Error("expected error for empty tileID on update")
+	}
+	if _, err := svc.DeleteTile(context.Background(), ""); err == nil {
+		t.Error("expected error for empty tileID on delete")
+	}
+	if _, err := svc.TileConfig(context.Background(), ""); err == nil {
+		t.Error("expected error for empty configType")
+	}
+	if _, err := svc.ReserveTileImage(context.Background(), ""); err == nil {
+		t.Error("expected error for empty tileID on reserve image")
+	}
+	if _, err := svc.GetImage(context.Background(), ""); err == nil {
+		t.Error("expected error for empty imageID")
+	}
+}
+
+func TestTileShowcaseAndConfig(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/12345/tile/showcase":
+			_, _ = w.Write([]byte(`{"categories":[{"type":"COVER","items":[{"id":"i1"}]}]}`))
+		case "/api/v1/12345/tile/config/COVER":
+			_, _ = w.Write([]byte(`{"type":"COVER","config":{"layoutConfigList":[]}}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	sc, err := svc.TileShowcase(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sc.Categories) != 1 || sc.Categories[0].Items[0].ID != "i1" {
+		t.Errorf("unexpected showcase: %+v", sc.Categories)
+	}
+	cfg, err := svc.TileConfig(context.Background(), "COVER")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Type != "COVER" || cfg.Config == nil {
+		t.Errorf("unexpected config: %+v", cfg)
+	}
+}
+
+// ── Tile images ───────────────────────────────────────────────────────────
+
+func TestTileImages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/12345/tile/t1/image" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"url":"https://upload","id":"img1"}`))
+		case r.URL.Path == "/api/v1/12345/image/img1":
+			_, _ = w.Write([]byte(`{"bucket":"eu-fra","set":[{"url":"https://cdn/x.jpg","width":800,"height":600}]}`))
+		case r.URL.Path == "/api/v1/12345/image/bucket":
+			_, _ = w.Write([]byte(`{"urls":{"eu-fra":"https://d2gt4h1eeousrn.cloudfront.net"}}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	res, err := svc.ReserveTileImage(context.Background(), "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ID != "img1" {
+		t.Errorf("expected id=img1, got %s", res.ID)
+	}
+	img, err := svc.GetImage(context.Background(), "img1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(img.Set) != 1 || img.Set[0].Width != 800 {
+		t.Errorf("unexpected image renditions: %+v", img.Set)
+	}
+	buckets, err := svc.ImageBuckets(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if buckets.URLs["eu-fra"] == "" {
+		t.Errorf("expected eu-fra bucket URL, got %+v", buckets.URLs)
+	}
+}
+
+// ── Themes ────────────────────────────────────────────────────────────────
+
+func TestThemes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v1/12345/themes" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"themes":[{"themeId":"th1","colors":{"colorA":"#fff"}}]}`))
+		case r.URL.Path == "/api/v1/12345/themes" && r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			if !strings.Contains(string(body), `"colors":{"colorA":"#000"}`) {
+				t.Errorf("expected colors envelope in body, got %s", body)
+			}
+			_, _ = w.Write([]byte(`{"themeId":"th2","colors":{"colorA":"#000"}}`))
+		case r.URL.Path == "/api/v1/12345/themes/th2" && r.Method == http.MethodPut:
+			_, _ = w.Write([]byte(`{"themeId":"th2","colors":{"colorA":"#111"}}`))
+		case r.URL.Path == "/api/v1/12345/themes/th2" && r.Method == http.MethodDelete:
+			_, _ = w.Write([]byte(`{"themeId":"th2","colors":{"colorA":"#111"}}`))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	list, err := svc.ListThemes(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Themes) != 1 || list.Themes[0].ThemeID != "th1" {
+		t.Errorf("unexpected themes: %+v", list.Themes)
+	}
+	created, err := svc.CreateTheme(context.Background(), &instantsite.ThemeColors{ColorA: "#000"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ThemeID != "th2" {
+		t.Errorf("expected themeId=th2, got %s", created.ThemeID)
+	}
+	if _, err := svc.UpdateTheme(context.Background(), "th2", &instantsite.ThemeColors{ColorA: "#111"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.DeleteTheme(context.Background(), "th2"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTheme_EmptyIDGuards(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("should not reach server")
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	if _, err := svc.UpdateTheme(context.Background(), "", &instantsite.ThemeColors{}); err == nil {
+		t.Error("expected error for empty themeID on update")
+	}
+	if _, err := svc.DeleteTheme(context.Background(), ""); err == nil {
+		t.Error("expected error for empty themeID on delete")
+	}
+}
+
+func TestCurrentTheme(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path != "/api/v1/12345/current_theme" {
+				t.Errorf("unexpected path: %s", r.URL.Path)
+			}
+			_, _ = w.Write([]byte(`{"colors":{"colorA":"#abc"}}`))
+		case http.MethodPut:
+			_, _ = w.Write([]byte(`{"themeId":"cur","colors":{"colorA":"#abc"}}`))
+		default:
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	cur, err := svc.CurrentTheme(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cur.Colors.ColorA != "#abc" {
+		t.Errorf("expected colorA=#abc, got %s", cur.Colors.ColorA)
+	}
+	updated, err := svc.UpdateCurrentTheme(context.Background(), &instantsite.ThemeColors{ColorA: "#abc"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.ThemeID != "cur" {
+		t.Errorf("expected themeId=cur, got %s", updated.ThemeID)
+	}
+}
+
+// ── Text labels ───────────────────────────────────────────────────────────
+
+func TestTextLabels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/12345/translation" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"editorTranslations":{"k":"v"},"languageTranslations":{"en":{"Language.en":"English"}}}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	labels, err := svc.TextLabels(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if labels.EditorTranslations["k"] != "v" {
+		t.Errorf("unexpected editorTranslations: %+v", labels.EditorTranslations)
+	}
+	if labels.LanguageTranslations["en"]["Language.en"] != "English" {
+		t.Errorf("unexpected languageTranslations: %+v", labels.LanguageTranslations)
+	}
+}
+
+// ── Redirects (v3, main requester) ────────────────────────────────────────
+
+func TestSearchRedirects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/12345/instant-site/redirects" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret_test" {
+			t.Errorf("expected main bearer token, got %q", got)
+		}
+		if r.URL.Query().Get("keyword") != "old" {
+			t.Errorf("expected keyword=old, got %s", r.URL.Query().Get("keyword"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":1,"count":1,"offset":0,"limit":10,"items":[{"id":"r1","fromUrl":"/old","toUrl":"/new"}]}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	result, err := svc.SearchRedirects(context.Background(), &instantsite.RedirectSearchOptions{Keyword: "old", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Total != 1 || result.Items[0].FromURL != "/old" {
+		t.Errorf("unexpected redirects: %+v", result)
+	}
+}
+
+func TestRedirectCRUD(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v3/12345/instant-site/redirects/r1" && r.Method == http.MethodGet:
+			_, _ = w.Write([]byte(`{"id":"r1","fromUrl":"/old","toUrl":"/new"}`))
+		case r.URL.Path == "/api/v3/12345/instant-site/redirects" && r.Method == http.MethodPost:
+			_, _ = w.Write([]byte(`{"id":"r2","fromUrl":"/a","toUrl":"/b"}`))
+		case r.URL.Path == "/api/v3/12345/instant-site/redirects/r2" && r.Method == http.MethodPut:
+			_, _ = w.Write([]byte(`{"id":"r2","fromUrl":"/a","toUrl":"/c"}`))
+		default:
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	got, err := svc.GetRedirect(context.Background(), "r1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ToURL != "/new" {
+		t.Errorf("expected toUrl=/new, got %s", got.ToURL)
+	}
+	created, err := svc.CreateRedirect(context.Background(), &instantsite.Redirect{FromURL: "/a", ToURL: "/b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "r2" {
+		t.Errorf("expected id=r2, got %s", created.ID)
+	}
+	updated, err := svc.UpdateRedirect(context.Background(), "r2", &instantsite.Redirect{FromURL: "/a", ToURL: "/c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.ToURL != "/c" {
+		t.Errorf("expected toUrl=/c, got %s", updated.ToURL)
+	}
+}
+
+func TestRedirect_EmptyIDGuards(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("should not reach server")
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	if _, err := svc.GetRedirect(context.Background(), ""); err == nil {
+		t.Error("expected error for empty redirectID on get")
+	}
+	if _, err := svc.UpdateRedirect(context.Background(), "", &instantsite.Redirect{}); err == nil {
+		t.Error("expected error for empty redirectID on update")
+	}
+}
+
+// ── Error handling ────────────────────────────────────────────────────────
+
+func TestSearchRedirects_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errorMessage":"forbidden","errorCode":"403"}`))
+	}))
+	defer srv.Close()
+
+	svc := newTestService(t, srv)
+	_, err := svc.SearchRedirects(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var apiErr *api.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *api.APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", apiErr.StatusCode)
+	}
+}
+
+// ensure encoding/json import is used for a compile-time sanity check on a
+// RawMessage round-trip of opaque tile content.
+func TestTileContentRoundTrip(t *testing.T) {
+	raw := json.RawMessage(`{"title":"Hi"}`)
+	tile := instantsite.Tile{Content: &raw}
+	data, err := json.Marshal(tile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"content":{"title":"Hi"}`) {
+		t.Errorf("expected content preserved, got %s", data)
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }

--- a/ecwid/instantsite/types.go
+++ b/ecwid/instantsite/types.go
@@ -1,0 +1,337 @@
+// Package instantsite provides access to the Ecwid Instant Site API.
+//
+// The Instant Site API spans two hosts and two tokens:
+//
+//   - Redirects (301 URL redirects) live on the main API host
+//     (app.ecwid.com/api/v3/{storeId}/instant-site/redirects) and use the main
+//     store access token — the same transport as every other domain service.
+//   - Everything else (profile, pages, tiles, tile images, themes, text labels,
+//     and the publish/discard/clone lifecycle) lives on the Instant Site v1 host
+//     (vuega.ecwid.com/api/v1/{storeId}/…) and uses a separate 24h token obtained
+//     via the token-exchange endpoint (app.ecwid.com/instantsite/oauth/token).
+//
+// Docs: https://docs.ecwid.com/api-reference/rest-api/instant-site
+package instantsite
+
+import "encoding/json"
+
+// ── Token exchange ──────────────────────────────────────────────────────────
+
+// GrantType values for the Instant Site token exchange.
+const (
+	// GrantTypeAuthorizationCode grants full Instant Site API access.
+	GrantTypeAuthorizationCode = "authorization_code"
+	// GrantTypeDraftCode grants editor/preview-only access.
+	GrantTypeDraftCode = "draft_code"
+)
+
+// TokenRequest holds the parameters for exchanging an app secret token for an
+// Instant Site access token. All fields are sent as query parameters.
+type TokenRequest struct {
+	// GrantType is "authorization_code" (full access) or "draft_code"
+	// (editor/preview only). Defaults to authorization_code when empty.
+	GrantType string
+	// SiteID is the Ecwid store ID.
+	SiteID string
+	// Code is the app secret token carrying the manage_instant_site scope.
+	Code string
+}
+
+// TokenResult is the response from the Instant Site token-exchange endpoint.
+type TokenResult struct {
+	AccessToken string `json:"accessToken"`
+	TokenType   string `json:"tokenType"`
+	ExpiresIn   int    `json:"expiresIn"`
+}
+
+// ── Profile ─────────────────────────────────────────────────────────────────
+
+// Profile is the Instant Site profile. GET returns the full object; create and
+// update accept the subset of mutable fields (locale, enabledLanguages,
+// storeName, countryCode, postalCode, email, dateFormat, timeFormat,
+// timezoneOffsetInMinutes).
+type Profile struct {
+	SiteID                                 string               `json:"siteId,omitempty"`
+	Locale                                 string               `json:"locale,omitempty"`
+	EnabledLanguages                       []string             `json:"enabledLanguages,omitempty"`
+	StoreName                              string               `json:"storeName,omitempty"`
+	Tracking                               *ProfileTracking     `json:"tracking,omitempty"`
+	CountryCode                            string               `json:"countryCode,omitempty"`
+	PostalCode                             string               `json:"postalCode,omitempty"`
+	Email                                  string               `json:"email,omitempty"`
+	DateFormat                             string               `json:"dateFormat,omitempty"`
+	TimeFormat                             string               `json:"timeFormat,omitempty"`
+	TimezoneOffsetInMinutes                int                  `json:"timezoneOffsetInMinutes,omitempty"`
+	StoreClosed                            *bool                `json:"storeClosed,omitempty"`
+	StoreSuspended                         *bool                `json:"storeSuspended,omitempty"`
+	IsTemplateSite                         *bool                `json:"isTemplateSite,omitempty"`
+	SiteURL                                string               `json:"siteUrl,omitempty"`
+	Subscription                           *ProfileSubscription `json:"subscription,omitempty"`
+	LatestPublishTimestamp                 int64                `json:"latestPublishTimestamp,omitempty"`
+	Onboarding                             *json.RawMessage     `json:"onboarding,omitempty"`
+	Vertical                               string               `json:"vertical,omitempty"`
+	PreviewTemplateInsideEditor            *bool                `json:"previewTemplateInsideEditor,omitempty"`
+	FeatureFlags                           *json.RawMessage     `json:"featureFlags,omitempty"`
+	IsDraftChanged                         *bool                `json:"isDraftChanged,omitempty"`
+	HideEcwidLinks                         *bool                `json:"hideEcwidLinks,omitempty"`
+	SelectedSiteTemplateID                 string               `json:"selectedSiteTemplateId,omitempty"`
+	EcwidAPIURL                            string               `json:"ecwidApiUrl,omitempty"`
+	StorefrontFiltersEnabled               *bool                `json:"storefrontFiltersEnabled,omitempty"`
+	StorefrontProductReviewsFeatureEnabled *bool                `json:"storefrontProductReviewsFeatureEnabled,omitempty"`
+}
+
+// ProfileTracking holds analytics tracking configuration on the profile.
+type ProfileTracking struct {
+	GoogleUniversalAnalyticsID string `json:"googleUniversalAnalyticsId,omitempty"`
+	HeapEnabled                *bool  `json:"heapEnabled,omitempty"`
+}
+
+// ProfileSubscription describes the store's plan/subscription as seen by the
+// Instant Site editor.
+type ProfileSubscription struct {
+	ChannelID                                 string `json:"channelId,omitempty"`
+	ChannelType                               string `json:"channelType,omitempty"`
+	PlanName                                  string `json:"planName,omitempty"`
+	PlanPeriod                                string `json:"planPeriod,omitempty"`
+	IsPaid                                    *bool  `json:"isPaid,omitempty"`
+	IsAllowNewCookieBanner                    *bool  `json:"isAllowNewCookieBanner,omitempty"`
+	MaxPageNumber                             int    `json:"maxPageNumber,omitempty"`
+	IsMultilingualStoreFeatureEnabled         *bool  `json:"isMultilingualStoreFeatureEnabled,omitempty"`
+	IsAdvancedDiscountsFeatureAvailable       *bool  `json:"isAdvancedDiscountsFeatureAvailable,omitempty"`
+	IsBasicEcommerceFeatureEnabled            *bool  `json:"isBasicEcommerceFeatureEnabled,omitempty"`
+	IsRichTextEditorEnabled                   *bool  `json:"isRichTextEditorEnabled,omitempty"`
+	IsTemplateMarketFeatureEnabled            *bool  `json:"isTemplateMarketFeatureEnabled,omitempty"`
+	IsAccessToControlPanel                    *bool  `json:"isAccessToControlPanel,omitempty"`
+	IsStorefrontAgeConfirmationFeatureEnabled *bool  `json:"isStorefrontAgeConfirmationFeatureEnabled,omitempty"`
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+// CloneRequest is the body for cloning an Instant Site from another store.
+type CloneRequest struct {
+	// Source is the store ID to copy settings from.
+	Source int `json:"source"`
+	// Draft, when false, publishes immediately; when true, saves as a draft.
+	Draft bool `json:"draft"`
+}
+
+// ── Pages ───────────────────────────────────────────────────────────────────
+
+// Page represents an Instant Site page.
+type Page struct {
+	PageID                 string `json:"pageId,omitempty"`
+	Title                  string `json:"title,omitempty"`
+	URLPath                string `json:"urlPath,omitempty"`
+	Visible                *bool  `json:"visible,omitempty"`
+	VisibleHeader          *bool  `json:"visibleHeader,omitempty"`
+	VisibleFooter          *bool  `json:"visibleFooter,omitempty"`
+	VisibleAnnouncementBar *bool  `json:"visibleAnnouncementBar,omitempty"`
+	SEOTitle               string `json:"seoTitle,omitempty"`
+	SEODescription         string `json:"seoDescription,omitempty"`
+	ShareImage             string `json:"shareImage,omitempty"`
+	Indexed                *bool  `json:"indexed,omitempty"`
+	IsAvailableToEdit      *bool  `json:"isAvailableToEdit,omitempty"`
+	// TileIDs is the ordered (top→bottom) list of tiles enabled on the page.
+	TileIDs []string `json:"tileIds,omitempty"`
+}
+
+// PageList is the response envelope for the list-pages endpoint.
+type PageList struct {
+	Pages []Page `json:"pages"`
+}
+
+// CreatePageResult is the response from creating a page.
+type CreatePageResult struct {
+	PageID string `json:"pageId"`
+}
+
+// ── Tiles ───────────────────────────────────────────────────────────────────
+
+// Tile represents an Instant Site tile (a section/block of a page). The
+// content, externalContent, design, and featuresEnabled fields are opaque and
+// vary by tile Type; their shape is described by the tile config endpoint
+// (see [Service.TileConfig]).
+type Tile struct {
+	ID              string           `json:"id,omitempty"`
+	Type            string           `json:"type,omitempty"`
+	Role            string           `json:"role,omitempty"`
+	TileName        string           `json:"tileName,omitempty"`
+	SourceID        string           `json:"sourceId,omitempty"`
+	Content         *json.RawMessage `json:"content,omitempty"`
+	ExternalContent *json.RawMessage `json:"externalContent,omitempty"`
+	Design          *json.RawMessage `json:"design,omitempty"`
+	Visibility      *bool            `json:"visibility,omitempty"`
+	Order           int              `json:"order,omitempty"`
+	HasChanges      *bool            `json:"hasChanges,omitempty"`
+	FeaturesEnabled *json.RawMessage `json:"featuresEnabled,omitempty"`
+}
+
+// TileList is the response envelope for the list-tiles endpoint.
+type TileList struct {
+	Tiles []Tile `json:"tiles"`
+}
+
+// TileListOptions holds query parameters for listing tiles.
+type TileListOptions struct {
+	// Published selects published (true) or draft (false) tiles. Required.
+	Published bool
+	// PageID optionally filters tiles to a single page.
+	PageID string
+	// Lang optionally requests translated text (2-letter language code).
+	Lang string
+}
+
+// TileUpdate is the mutable subset of a tile used by update operations.
+type TileUpdate struct {
+	ID         string           `json:"id,omitempty"`
+	TileName   string           `json:"tileName,omitempty"`
+	Content    *json.RawMessage `json:"content,omitempty"`
+	Design     *json.RawMessage `json:"design,omitempty"`
+	Visibility *bool            `json:"visibility,omitempty"`
+	Order      int              `json:"order,omitempty"`
+	HasChanges *bool            `json:"hasChanges,omitempty"`
+}
+
+// TileBulkUpdate is the body for updating the whole tiles list at once.
+type TileBulkUpdate struct {
+	Tiles []TileUpdate `json:"tiles"`
+}
+
+// TileCreateBody is the tile payload nested inside a CreateTileRequest.
+type TileCreateBody struct {
+	Type       string           `json:"type,omitempty"`
+	TileName   string           `json:"tileName,omitempty"`
+	Content    *json.RawMessage `json:"content,omitempty"`
+	Design     *json.RawMessage `json:"design,omitempty"`
+	Visibility *bool            `json:"visibility,omitempty"`
+	Order      int              `json:"order,omitempty"`
+	HasChanges *bool            `json:"hasChanges,omitempty"`
+}
+
+// CreateTileRequest is the body for creating a tile.
+type CreateTileRequest struct {
+	TileShowcaseItemID string          `json:"tileShowcaseItemId,omitempty"`
+	TileCategoryType   string          `json:"tileCategoryType,omitempty"`
+	TileOrder          int             `json:"tileOrder,omitempty"`
+	UseTileShowcase    *bool           `json:"useTileShowcase,omitempty"`
+	PageID             string          `json:"pageId,omitempty"`
+	Tile               *TileCreateBody `json:"tile,omitempty"`
+}
+
+// TileShowcaseResult is the response for the available tile templates.
+type TileShowcaseResult struct {
+	Categories []TileShowcaseCategory `json:"categories"`
+}
+
+// TileShowcaseCategory groups showcase items by tile category type.
+type TileShowcaseCategory struct {
+	Type  string             `json:"type"`
+	Items []TileShowcaseItem `json:"items"`
+}
+
+// TileShowcaseItem is a single available tile template.
+type TileShowcaseItem struct {
+	ID              string `json:"id"`
+	PreviewImageURL string `json:"previewImageUrl,omitempty"`
+	PreviewHeight   int    `json:"previewHeight,omitempty"`
+	PreviewWidth    int    `json:"previewWidth,omitempty"`
+	FeatureProperty string `json:"featureProperty,omitempty"`
+	IsDeprecated    *bool  `json:"isDeprecated,omitempty"`
+}
+
+// TileConfigResult is the response for a tile config by category type. The
+// config payload is opaque (layoutConfigList with per-type editor configs).
+type TileConfigResult struct {
+	Type   string           `json:"type"`
+	Config *json.RawMessage `json:"config,omitempty"`
+}
+
+// ── Tile images ─────────────────────────────────────────────────────────────
+
+// ReserveImageResult is the response from reserving a tile image upload. Clients
+// then POST the image binary as multipart/form-data to URL.
+type ReserveImageResult struct {
+	URL string `json:"url"`
+	ID  string `json:"id"`
+}
+
+// ImageResult is the response describing an uploaded tile image.
+type ImageResult struct {
+	Bucket     string           `json:"bucket,omitempty"`
+	Set        []ImageRendition `json:"set,omitempty"`
+	BorderInfo *json.RawMessage `json:"borderInfo,omitempty"`
+}
+
+// ImageRendition is a single rendered size of an uploaded image.
+type ImageRendition struct {
+	URL    string `json:"url"`
+	Width  int    `json:"width,omitempty"`
+	Height int    `json:"height,omitempty"`
+}
+
+// ImageBucketsResult maps image bucket IDs to their CDN base URLs.
+type ImageBucketsResult struct {
+	URLs map[string]string `json:"urls"`
+}
+
+// ── Themes ──────────────────────────────────────────────────────────────────
+
+// ThemeColors is the six-color palette of an Instant Site theme.
+type ThemeColors struct {
+	ColorA string `json:"colorA,omitempty"`
+	ColorB string `json:"colorB,omitempty"`
+	ColorC string `json:"colorC,omitempty"`
+	ColorD string `json:"colorD,omitempty"`
+	ColorE string `json:"colorE,omitempty"`
+	ColorF string `json:"colorF,omitempty"`
+}
+
+// Theme is a named color palette.
+type Theme struct {
+	ThemeID string      `json:"themeId,omitempty"`
+	Colors  ThemeColors `json:"colors"`
+}
+
+// ThemeList is the response envelope for the list-themes endpoint.
+type ThemeList struct {
+	Themes []Theme `json:"themes"`
+}
+
+// CurrentTheme is the response from the current-theme endpoint.
+type CurrentTheme struct {
+	Colors ThemeColors `json:"colors"`
+}
+
+// ── Text labels ─────────────────────────────────────────────────────────────
+
+// TextLabels is the response for the Instant Site text labels (i18n) endpoint.
+type TextLabels struct {
+	EditorTranslations   map[string]string            `json:"editorTranslations,omitempty"`
+	WebsiteTranslations  map[string]string            `json:"websiteTranslations,omitempty"`
+	LanguageTranslations map[string]map[string]string `json:"languageTranslations,omitempty"`
+}
+
+// ── Redirects (v3) ──────────────────────────────────────────────────────────
+
+// Redirect is a single 301 URL redirect.
+type Redirect struct {
+	ID      string `json:"id,omitempty"`
+	FromURL string `json:"fromUrl"`
+	ToURL   string `json:"toUrl"`
+}
+
+// RedirectSearchResult is the paginated response from the redirects search API.
+type RedirectSearchResult struct {
+	Total  int        `json:"total"`
+	Count  int        `json:"count"`
+	Offset int        `json:"offset"`
+	Limit  int        `json:"limit"`
+	Items  []Redirect `json:"items"`
+}
+
+// RedirectSearchOptions holds query parameters for searching redirects.
+type RedirectSearchOptions struct {
+	Keyword string
+	Offset  int
+	Limit   int
+}

--- a/ecwid/instantsite/types.go
+++ b/ecwid/instantsite/types.go
@@ -61,7 +61,7 @@ type Profile struct {
 	Email                                  string               `json:"email,omitempty"`
 	DateFormat                             string               `json:"dateFormat,omitempty"`
 	TimeFormat                             string               `json:"timeFormat,omitempty"`
-	TimezoneOffsetInMinutes                int                  `json:"timezoneOffsetInMinutes,omitempty"`
+	TimezoneOffsetInMinutes                *int                 `json:"timezoneOffsetInMinutes,omitempty"`
 	StoreClosed                            *bool                `json:"storeClosed,omitempty"`
 	StoreSuspended                         *bool                `json:"storeSuspended,omitempty"`
 	IsTemplateSite                         *bool                `json:"isTemplateSite,omitempty"`


### PR DESCRIPTION
## Summary

Adds the **full Ecwid Instant Site API** to the client, matching the existing house style and wired end-to-end (client → CLI → mock server → e2e).

The Instant Site API is unusual: it spans **two hosts and two tokens**, so the new `ecwid/instantsite.Service` routes across three requesters (no transport changes — just extra `api.HTTPClient` instances):

| Sub-area | Host | Token |
|---|---|---|
| Redirects (search/get/create/update) | `app.ecwid.com/api/v3/{storeId}/instant-site/redirects` | main store token |
| Profile, pages, tiles, tile images, themes, text labels, publish/discard/clone | `vuega.ecwid.com/api/v1/{storeId}/…` (configurable) | separate 24h Instant Site token |
| Token exchange | `app.ecwid.com/instantsite/oauth/token` | app secret token (as `code`) |

Opaque per-tile fields (`content`/`design`/`externalContent`/`featuresEnabled`) are modelled as `*json.RawMessage`, driven by the `tile/config/{type}` endpoint.

## Changes

- **`ecwid/instantsite/`** — new package: `service.go` (~30 methods), `types.go`, `service_test.go` (per-method path/method/query/decoding + zero-ID guards + typed-error test).
- **`config`** — `InstantSiteBaseURL` / `InstantSiteAuthURL` / `InstantSiteToken` (defaults applied in `WithDefaults`; `InstantSiteToken` redacted in `MarshalJSON`).
- **`ecwid.Client`** — builds the v1 + auth requesters and exposes `client.InstantSite`.
- **CLI** — `ecwid instantsite …` command tree (profile / draft / pages / tiles / images / themes / text-labels / redirects / token) with `--instant-site-*` flags + `ECWID_INSTANT_SITE_*` env.
- **Tests** — mock-server handlers for both hosts + token exchange; CLI integration tests exercising the real binary against both hosts; read-only e2e tests (gated on the Instant Site token).
- **README** — coverage row.

## Verification

- `task test` — all modules pass with `-race` (new unit tests + CLI integration tests through the real client code path).
- `task build` — binary builds; command tree correct.
- Lint: `config`/`ecwid` clean; new code clean (0 issues). Any local `task lint` noise is 3 pre-existing govet `inline` warnings in unmodified `cli/internal/cmdutil/output.go`, an artifact of a newer local golangci-lint vs the CI-pinned v2.11.1 — unrelated to this change.

## Note — verify before production use

The v1 host default (`vuega.ecwid.com/api/v1`) is taken from the official docs but was **not verified against a live store** (no token available). It is fully configurable via `InstantSiteBaseURL`. The profile response includes an `ecwidApiUrl` field, hinting the host could be store-specific — worth one live call to confirm, or to drive auto-discovery in a follow-up. The redirect (v3) endpoints need no such caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Instant Site API support, including profile, page, tile, image, theme, translation, draft, and redirect management.
  * Added CLI commands for Instant Site operations, with JSON input support through files or standard input.
  * Added configurable Instant Site endpoints and secure token handling.
* **Documentation**
  * Updated feature and API coverage documentation to include Instant Site.
* **Tests**
  * Added integration, end-to-end, and service coverage for Instant Site workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->