### PR TITLE
feat(webhooks): typed events, signature verification, and handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,14 @@ h, err := webhooks.NewHandler(clientSecret, func(ctx context.Context, e webhooks
 	if e.EventType != webhooks.EventOrderCreated {
 		return
 	}
-	// Re-fetch rather than trusting e.Data — see the caveat below.
-	order, err := client.Orders.Get(ctx, e.EntityID)
+	// Order events carry the *internal* ID in EntityID, which the order
+	// endpoints don't accept — the usable one is in the payload.
+	d, err := e.OrderData()
+	if err != nil {
+		return
+	}
+	// Re-fetch rather than trusting the rest of e.Data — see the caveat below.
+	order, err := client.Orders.Get(ctx, d.OrderID)
 	// ...
 }, &webhooks.Options{MaxAge: 5 * time.Minute})
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Go client library and CLI for the [Ecwid REST API](https://docs.ecwid.com/api-re
 ## Features
 
 - **Full Ecwid API coverage** — Products, Orders, Customers, Categories, Carts, Subscriptions, Promotions, Coupons, Reviews, Store Profile, Staff, Domains, Instant Site, Dictionaries, Reports
+- **Webhooks** — Typed events, constant-time signature verification that fails closed, and an `http.Handler` with replay defenses
 - **Stdlib only** — Zero external dependencies in config and client modules
 - **Stateless** — No internal state; credentials passed explicitly per client
 - **Multi-module** — Clean separation: `config/`, `ecwid/`, `cli/` with independent `go.mod`s
@@ -156,6 +157,36 @@ Ecwid allows **600 requests/minute per token**.
 - `MaxRetries: 0` (default): 429 responses surface as `*ecwid.RateLimitError` with `RetryAfter`.
 - `MaxRetries: N`: Client auto-retries up to N times, respecting `Retry-After` and context cancellation.
 
+## Webhooks
+
+`ecwid/webhooks` provides typed events, signature verification, and an `http.Handler`:
+
+```go
+h, err := webhooks.NewHandler(clientSecret, func(ctx context.Context, e webhooks.Event) {
+	if e.EventType != webhooks.EventOrderCreated {
+		return
+	}
+	// Re-fetch rather than trusting e.Data — see the caveat below.
+	order, err := client.Orders.Get(ctx, e.EntityID)
+	// ...
+}, &webhooks.Options{MaxAge: 5 * time.Minute})
+if err != nil {
+	return err
+}
+mux.Handle("POST /webhooks/ecwid", h)
+```
+
+The handler responds before running your callback (Ecwid allows 10s), fails closed on a
+missing signature, and defaults to a 200 — Ecwid counts 203, 208 and every 3xx as a failed
+delivery, so an endpoint that redirects HTTP to HTTPS silently never receives a webhook.
+
+> **The webhook signature does not cover the request body.** It is an HMAC over only
+> `"<eventCreated>.<eventId>"`, keyed with the app's `client_secret`. Everything else —
+> `storeId`, `eventType`, `entityId`, `data` — is unauthenticated, and a captured webhook
+> stays replayable forever. Dedupe on `EventID` (`Options.Deduper`), bound staleness with
+> `Options.MaxAge`, and re-fetch the entity by `EntityID` instead of trusting `Data`.
+> See the [package docs](https://pkg.go.dev/github.com/matthiasbruns/ecwid-go/ecwid/webhooks).
+
 ## API Coverage
 
 | Domain | Service | Status |
@@ -175,6 +206,7 @@ Ecwid allows **600 requests/minute per token**.
 | Dictionaries | `DictionaryService` | 🔲 |
 | Staff | `StaffService` | 🔲 |
 | Reports | `ReportService` | 🔲 |
+| Webhooks | `webhooks` package | ✅ |
 | CLI | Cobra commands | 🔲 |
 | E2E Tests | Real store tests | 🔲 |
 

--- a/ecwid/webhooks/doc.go
+++ b/ecwid/webhooks/doc.go
@@ -1,0 +1,66 @@
+// Package webhooks provides typed Ecwid webhook events, signature verification,
+// and an [http.Handler] that verifies and dispatches them.
+//
+// # Security model
+//
+// Read this before trusting anything a webhook tells you.
+//
+// The Ecwid webhook signature does NOT cover the request body. It is an HMAC over
+// only two fields — "<eventCreated>.<eventId>" — taken from the parsed JSON body
+// and keyed with the app's client_secret. Three consequences follow:
+//
+//   - The payload is unauthenticated. storeId, eventType, entityId and data are
+//     not covered by the signature. An attacker who observes one valid
+//     (eventCreated, eventId, signature) triple can attach any body to it.
+//   - Webhooks are fully replayable. The signature never expires, so a captured
+//     request stays valid forever.
+//   - Only possession of a signature for a given (eventCreated, eventId) pair is
+//     proven — not the integrity of what arrived with it.
+//
+// Defend in depth:
+//
+//   - Dedupe on EventID, so a replayed event is processed at most once. See
+//     [Deduper].
+//   - Enforce a recency window on EventCreated, so old captures are rejected.
+//     See [Options.MaxAge].
+//   - Re-fetch the entity over the REST API using EntityID rather than trusting
+//     Data. Treat Data as a hint about what changed, never as the source of truth.
+//
+// [Handler] wires up the first two; the third is yours to do in the callback.
+//
+// # Delivery semantics
+//
+// Ecwid allows 3s to connect and 10s for the response. [Handler] therefore
+// responds before invoking your callback.
+//
+// Ecwid counts only 200, 201, 202, 204 and 209 as success. Note the traps: 203
+// and 208 are failures despite being 2xx, and every 3xx is a failure — an
+// endpoint that 301-redirects HTTP to HTTPS silently never receives a webhook.
+// [Handler] responds 200 by default.
+//
+// A failed delivery is retried 27 times over 24 hours (15min, 30min, 45min, 1h,
+// 2h, 3h, 4h, 5h, 6h, ... with the final attempt at 24h; the intervals between
+// attempts 10 and 26 are elided in Ecwid's documentation and are unconfirmed).
+// If an endpoint fails to respond for two weeks, webhooks for the app are
+// blocked entirely. Combined with the retries, delivery is at-least-once:
+// your callback must be idempotent.
+//
+// Webhooks fire regardless of what caused the change — creating an order through
+// the REST API still emits order.created. Integrations that write back to Ecwid
+// in response to a webhook can trigger themselves in a loop.
+//
+// # Usage
+//
+//	h, err := webhooks.NewHandler(clientSecret, func(ctx context.Context, e webhooks.Event) {
+//		if e.EventType != webhooks.EventOrderCreated {
+//			return
+//		}
+//		// Re-fetch rather than trusting e.Data.
+//		order, err := client.Orders.Get(ctx, e.EntityID)
+//		// ...
+//	}, &webhooks.Options{MaxAge: 5 * time.Minute})
+//	if err != nil {
+//		return err
+//	}
+//	mux.Handle("POST /webhooks/ecwid", h)
+package webhooks

--- a/ecwid/webhooks/doc.go
+++ b/ecwid/webhooks/doc.go
@@ -55,8 +55,15 @@
 //		if e.EventType != webhooks.EventOrderCreated {
 //			return
 //		}
-//		// Re-fetch rather than trusting e.Data.
-//		order, err := client.Orders.Get(ctx, e.EntityID)
+//		// Order events are the exception to re-fetching by EntityID: theirs is
+//		// the internal ID, which the order endpoints do not accept. The ID they
+//		// want is in the payload.
+//		d, err := e.OrderData()
+//		if err != nil {
+//			return
+//		}
+//		// Re-fetch rather than trusting the rest of e.Data.
+//		order, err := client.Orders.Get(ctx, d.OrderID)
 //		// ...
 //	}, &webhooks.Options{MaxAge: 5 * time.Minute})
 //	if err != nil {

--- a/ecwid/webhooks/handler.go
+++ b/ecwid/webhooks/handler.go
@@ -1,0 +1,225 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"time"
+)
+
+// maxBodyBytes caps a webhook body. Ecwid's payloads are a few hundred bytes;
+// this is generous enough to never reject a real one and small enough that an
+// unauthenticated POST cannot exhaust memory.
+const maxBodyBytes = 1 << 20 // 1 MiB
+
+// successCodes are the responses Ecwid accepts as a successful delivery.
+// Everything else, including 203, 208 and every 3xx, is a failed delivery that
+// Ecwid will retry.
+var successCodes = []int{
+	http.StatusOK,        // 200
+	http.StatusCreated,   // 201
+	http.StatusAccepted,  // 202
+	http.StatusNoContent, // 204
+	209,                  // no net/http constant; not a registered IANA code
+}
+
+// Deduper records which events have been processed, so a replayed or retried
+// webhook runs the callback at most once.
+//
+// Implementations must be safe for concurrent use, and should record eventID and
+// report its prior presence atomically — a check-then-set that is not atomic
+// lets two concurrent deliveries of the same event both run the callback.
+//
+// Entries only need to outlive Ecwid's 24h retry window, but because a signature
+// never expires, retaining them longer is what blunts a replay. There is no
+// built-in implementation: dedupe state must be shared across every replica of
+// your service, so it belongs in whatever store you already run.
+type Deduper interface {
+	// Seen records eventID and reports whether it was already present.
+	Seen(ctx context.Context, eventID string) (bool, error)
+}
+
+// Options configures a [Handler]. The zero value is valid.
+type Options struct {
+	// SuccessCode is the status returned for an accepted webhook. It must be one
+	// Ecwid accepts: 200, 201, 202, 204 or 209. Defaults to 200.
+	SuccessCode int
+
+	// MaxAge rejects events whose EventCreated is older than this, which bounds
+	// how long a captured webhook stays replayable. Ecwid retries a failed
+	// delivery for up to 24h, so a window shorter than that can drop legitimate
+	// retries of an event your endpoint was down for; weigh that against the
+	// replay exposure. Zero disables the check, accepting events of any age.
+	MaxAge time.Duration
+
+	// Deduper suppresses events whose EventID has already been processed.
+	// Optional; nil disables deduplication, and the callback then runs once per
+	// delivery rather than once per event.
+	Deduper Deduper
+
+	// OnError is called when a webhook is rejected or dropped, for logging and
+	// metrics. It must not log the signature or the client secret. Optional.
+	//
+	// It reports problems the response cannot: a rejected request is answered
+	// long before the callback would run, and a Deduper failure is invisible to
+	// the caller entirely.
+	OnError func(r *http.Request, err error)
+}
+
+// Handler verifies Ecwid webhooks and dispatches them to a callback.
+//
+// It responds to Ecwid before invoking the callback, so a slow callback cannot
+// trip Ecwid's 10s response timeout and cause a redelivery. The callback still
+// runs on the request's goroutine — it occupies a server connection until it
+// returns, so hand off genuinely long work to your own queue.
+//
+// Requests are answered with the configured success code once the signature
+// verifies; with 401 if it does not, 400 for an unparseable body, 405 for a
+// non-POST, and 413 for an oversized one.
+type Handler struct {
+	clientSecret string
+	handle       func(context.Context, Event)
+	successCode  int
+	maxAge       time.Duration
+	deduper      Deduper
+	onError      func(*http.Request, error)
+	now          func() time.Time // overridden in tests
+}
+
+// NewHandler builds a [Handler] that verifies webhooks with clientSecret — the
+// app's client_secret, not an access token — and passes those that verify to
+// handle. opts may be nil.
+//
+// The callback must be idempotent: Ecwid retries a failed delivery up to 27
+// times over 24h, so the same event can arrive more than once. It must also be
+// safe for concurrent use, as deliveries are not serialized.
+//
+// Treat [Event.Data] as a hint about what changed, not as fact — it is not
+// covered by the signature. Re-fetch the entity by [Event.EntityID] over the
+// REST API before acting on it.
+func NewHandler(clientSecret string, handle func(ctx context.Context, e Event), opts *Options) (*Handler, error) {
+	if clientSecret == "" {
+		return nil, errors.New("webhooks: clientSecret must not be empty")
+	}
+	if handle == nil {
+		return nil, errors.New("webhooks: handle must not be nil")
+	}
+	if opts == nil {
+		opts = &Options{}
+	}
+
+	code := opts.SuccessCode
+	if code == 0 {
+		code = http.StatusOK
+	}
+	if !slices.Contains(successCodes, code) {
+		return nil, fmt.Errorf("webhooks: SuccessCode %d is not one Ecwid accepts (want one of %v)", code, successCodes)
+	}
+	if opts.MaxAge < 0 {
+		return nil, fmt.Errorf("webhooks: MaxAge must not be negative, got %s", opts.MaxAge)
+	}
+
+	return &Handler{
+		clientSecret: clientSecret,
+		handle:       handle,
+		successCode:  code,
+		maxAge:       opts.MaxAge,
+		deduper:      opts.Deduper,
+		onError:      opts.OnError,
+		now:          time.Now,
+	}, nil
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		h.reject(w, r, http.StatusMethodNotAllowed, fmt.Errorf("webhooks: method %s not allowed", r.Method))
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBodyBytes))
+	if err != nil {
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			h.reject(w, r, http.StatusRequestEntityTooLarge, fmt.Errorf("webhooks: body exceeds %d bytes", maxBodyBytes))
+			return
+		}
+		h.reject(w, r, http.StatusBadRequest, fmt.Errorf("webhooks: read body: %w", err))
+		return
+	}
+
+	var e Event
+	if err := json.Unmarshal(body, &e); err != nil {
+		h.reject(w, r, http.StatusBadRequest, fmt.Errorf("webhooks: parse body: %w", err))
+		return
+	}
+
+	// Verify before anything else touches the event: until this passes, every
+	// field above is attacker-controlled.
+	if err := Verify(r.Header.Get(SignatureHeader), e.EventCreated, e.EventID, h.clientSecret); err != nil {
+		status := http.StatusUnauthorized
+		if !errors.Is(err, ErrInvalidSignature) {
+			// A misconfigured secret is our fault, not the sender's.
+			status = http.StatusInternalServerError
+		}
+		h.reject(w, r, status, err)
+		return
+	}
+
+	// Answer with a success code even for events we drop below: they are
+	// authentic and a failure response would only earn 27 retries of an event we
+	// have already decided not to process.
+	if h.maxAge > 0 {
+		if age := h.now().Sub(time.Unix(e.EventCreated, 0)); age > h.maxAge {
+			w.WriteHeader(h.successCode)
+			h.report(r, fmt.Errorf("webhooks: dropped event %s: age %s exceeds MaxAge %s", e.EventID, age.Round(time.Second), h.maxAge))
+			return
+		}
+	}
+
+	w.WriteHeader(h.successCode)
+	// Flush so Ecwid has its response before the callback starts; without this
+	// the response could sit buffered until ServeHTTP returns.
+	if err := http.NewResponseController(w).Flush(); err != nil {
+		// Unsupported by this ResponseWriter, or the peer is gone. Neither is
+		// worth dropping an authentic event over — the response is already
+		// written, and the callback below does not depend on it.
+		h.report(r, fmt.Errorf("webhooks: flush response: %w", err))
+	}
+
+	// Detach from the request context: it is canceled when ServeHTTP returns,
+	// and Ecwid may close the connection as soon as it reads the response above.
+	// Neither should abort a callback that has already been promised success.
+	ctx := context.WithoutCancel(r.Context())
+
+	if h.deduper != nil {
+		seen, err := h.deduper.Seen(ctx, e.EventID)
+		if err != nil {
+			// Fail open. Delivery is at-least-once regardless, so a callback that
+			// is not idempotent is already broken; dropping the event instead
+			// would turn a flaky dedupe store into silent data loss.
+			h.report(r, fmt.Errorf("webhooks: dedupe event %s: %w", e.EventID, err))
+		} else if seen {
+			return
+		}
+	}
+
+	h.handle(ctx, e)
+}
+
+// reject writes an error status and reports why.
+func (h *Handler) reject(w http.ResponseWriter, r *http.Request, status int, err error) {
+	// The body is deliberately generic: the sender is unauthenticated, so err
+	// goes to OnError, not over the wire.
+	http.Error(w, http.StatusText(status), status)
+	h.report(r, err)
+}
+
+func (h *Handler) report(r *http.Request, err error) {
+	if h.onError != nil {
+		h.onError(r, err)
+	}
+}

--- a/ecwid/webhooks/handler.go
+++ b/ecwid/webhooks/handler.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"time"
 )
 
@@ -16,15 +15,26 @@ import (
 // unauthenticated POST cannot exhaust memory.
 const maxBodyBytes = 1 << 20 // 1 MiB
 
-// successCodes are the responses Ecwid accepts as a successful delivery.
+// isSuccessCode reports whether Ecwid accepts status as a successful delivery.
 // Everything else, including 203, 208 and every 3xx, is a failed delivery that
 // Ecwid will retry.
-var successCodes = []int{
-	http.StatusOK,        // 200
-	http.StatusCreated,   // 201
-	http.StatusAccepted,  // 202
-	http.StatusNoContent, // 204
-	209,                  // no net/http constant; not a registered IANA code
+func isSuccessCode(status int) bool {
+	switch status {
+	case http.StatusOK, // 200
+		http.StatusCreated,   // 201
+		http.StatusAccepted,  // 202
+		http.StatusNoContent, // 204
+		209:                  // no net/http constant; not a registered IANA code
+		return true
+	default:
+		return false
+	}
+}
+
+// successCodes lists those same codes for error messages and tests. It returns a
+// fresh slice per call, so there is no package-level state to mutate.
+func successCodes() []int {
+	return []int{http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent, 209}
 }
 
 // Deduper records which events have been processed, so a replayed or retried
@@ -38,6 +48,14 @@ var successCodes = []int{
 // never expires, retaining them longer is what blunts a replay. There is no
 // built-in implementation: dedupe state must be shared across every replica of
 // your service, so it belongs in whatever store you already run.
+//
+// Seen is called on receipt, before the callback runs, because marking an event
+// only after the callback would let two concurrent deliveries — or a replay
+// arriving mid-callback — both through, which is the case this exists to stop.
+// The cost is a crash window: if the process dies between Seen and the callback
+// completing, Ecwid's retry is deduped and the event is dropped. If losing an
+// event is worse for you than handling one twice, have the callback record its
+// own completion and let Seen consult that.
 type Deduper interface {
 	// Seen records eventID and reports whether it was already present.
 	Seen(ctx context.Context, eventID string) (bool, error)
@@ -100,7 +118,8 @@ type Handler struct {
 //
 // Treat [Event.Data] as a hint about what changed, not as fact — it is not
 // covered by the signature. Re-fetch the entity by [Event.EntityID] over the
-// REST API before acting on it.
+// REST API before acting on it. Order events are the exception: their EntityID
+// is the internal order ID, so re-fetch those by [OrderData.OrderID] instead.
 func NewHandler(clientSecret string, handle func(ctx context.Context, e Event), opts *Options) (*Handler, error) {
 	if clientSecret == "" {
 		return nil, errors.New("webhooks: clientSecret must not be empty")
@@ -116,8 +135,8 @@ func NewHandler(clientSecret string, handle func(ctx context.Context, e Event), 
 	if code == 0 {
 		code = http.StatusOK
 	}
-	if !slices.Contains(successCodes, code) {
-		return nil, fmt.Errorf("webhooks: SuccessCode %d is not one Ecwid accepts (want one of %v)", code, successCodes)
+	if !isSuccessCode(code) {
+		return nil, fmt.Errorf("webhooks: SuccessCode %d is not one Ecwid accepts (want one of %v)", code, successCodes())
 	}
 	if opts.MaxAge < 0 {
 		return nil, fmt.Errorf("webhooks: MaxAge must not be negative, got %s", opts.MaxAge)

--- a/ecwid/webhooks/handler_test.go
+++ b/ecwid/webhooks/handler_test.go
@@ -325,7 +325,7 @@ func TestHandler_OnErrorNeverLeaksSecrets(t *testing.T) {
 }
 
 func TestHandler_SuccessCode(t *testing.T) {
-	for _, code := range successCodes {
+	for _, code := range successCodes() {
 		t.Run(fmt.Sprint(code), func(t *testing.T) {
 			var rec recorder
 			h := newTestHandler(t, rec.handle, &Options{SuccessCode: code})
@@ -409,15 +409,37 @@ func TestHandler_RespondsBeforeCallback(t *testing.T) {
 	}
 	req.Header.Set(SignatureHeader, sign(testEventCreated, testEventID, testSecret))
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("Do() = %v", err)
+	// Do runs asynchronously: should the handler ever wait for the callback
+	// before responding, it and the callback would wait on each other forever,
+	// and a synchronous Do would hang the test rather than fail it.
+	type result struct {
+		status int
+		err    error
 	}
-	defer func() { _ = resp.Body.Close() }()
+	done := make(chan result, 1)
+	go func() {
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		defer func() { _ = resp.Body.Close() }()
+		done <- result{status: resp.StatusCode}
+	}()
 
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("Do() = %v", got.err)
+		}
+		if got.status != http.StatusOK {
+			t.Errorf("status = %d, want %d", got.status, http.StatusOK)
+		}
+	case <-time.After(5 * time.Second):
+		close(responded) // Unblock the callback so the server can shut down.
+		t.Fatal("handler did not respond until after the callback ran")
 	}
+
 	close(responded)
 
 	select {

--- a/ecwid/webhooks/handler_test.go
+++ b/ecwid/webhooks/handler_test.go
@@ -1,0 +1,500 @@
+package webhooks
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recorder captures the events a handler dispatches.
+type recorder struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+func (r *recorder) handle(_ context.Context, e Event) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, e)
+}
+
+func (r *recorder) get() []Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]Event(nil), r.events...)
+}
+
+// mapDeduper is an in-memory [Deduper] for tests only. Real deployments need one
+// backed by a store shared across replicas.
+type mapDeduper struct {
+	mu   sync.Mutex
+	seen map[string]bool
+	err  error
+}
+
+func (d *mapDeduper) Seen(_ context.Context, eventID string) (bool, error) {
+	if d.err != nil {
+		return false, d.err
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.seen == nil {
+		d.seen = map[string]bool{}
+	}
+	was := d.seen[eventID]
+	d.seen[eventID] = true
+	return was, nil
+}
+
+const orderCreatedBody = `{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":1234567,"storeId":1003,"entityId":103878161,"eventType":"order.created","data":{"orderId":"XJ12H","newPaymentStatus":"PAID","newFulfillmentStatus":"SHIPPED"}}`
+
+// newRequest builds a webhook request, signing it correctly unless signature is
+// non-nil, in which case that literal value is used.
+func newRequest(body string, signature *string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/webhooks", strings.NewReader(body))
+	if signature != nil {
+		if *signature != "" {
+			r.Header.Set(SignatureHeader, *signature)
+		}
+		return r
+	}
+	var e Event
+	if err := json.Unmarshal([]byte(body), &e); err == nil {
+		r.Header.Set(SignatureHeader, sign(e.EventCreated, e.EventID, testSecret))
+	}
+	return r
+}
+
+// newTestHandler builds a handler with a fixed clock, so MaxAge tests do not
+// depend on the wall clock.
+func newTestHandler(t *testing.T, handle func(context.Context, Event), opts *Options) *Handler {
+	t.Helper()
+	h, err := NewHandler(testSecret, handle, opts)
+	if err != nil {
+		t.Fatalf("NewHandler() = %v", err)
+	}
+	h.now = func() time.Time { return time.Unix(testEventCreated, 0) }
+	return h
+}
+
+func TestHandler_ValidEvent(t *testing.T) {
+	var rec recorder
+	h := newTestHandler(t, rec.handle, nil)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newRequest(orderCreatedBody, nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	got := rec.get()
+	if len(got) != 1 {
+		t.Fatalf("callback fired %d times, want 1", len(got))
+	}
+	if got[0].EventType != EventOrderCreated {
+		t.Errorf("EventType = %q, want %q", got[0].EventType, EventOrderCreated)
+	}
+	if got[0].EntityID != "103878161" {
+		t.Errorf("EntityID = %q, want %q", got[0].EntityID, "103878161")
+	}
+	d, err := got[0].OrderData()
+	if err != nil {
+		t.Fatalf("OrderData() = %v", err)
+	}
+	if d.OrderID != "XJ12H" {
+		t.Errorf("OrderData().OrderID = %q, want %q", d.OrderID, "XJ12H")
+	}
+}
+
+func TestHandler_RejectsBadSignature(t *testing.T) {
+	bad := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	empty := ""
+
+	tests := []struct {
+		name       string
+		body       string
+		signature  *string
+		wantStatus int
+	}{
+		{"wrong signature", orderCreatedBody, &bad, http.StatusUnauthorized},
+		{"missing signature header fails closed", orderCreatedBody, &empty, http.StatusUnauthorized},
+		{
+			// The signature covers only eventCreated and eventId, so a body whose
+			// other fields were swapped still verifies. Confirm that a body whose
+			// *signed* fields were altered does not.
+			name:       "tampered eventId",
+			body:       strings.Replace(orderCreatedBody, `"eventId":"80aece08-40e8-4145-8764-6c2f0d38678"`, `"eventId":"00000000-0000-0000-0000-000000000000"`, 1),
+			signature:  new(sign(testEventCreated, testEventID, testSecret)),
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "signature from a different secret",
+			body:       orderCreatedBody,
+			signature:  new(sign(testEventCreated, testEventID, "some_other_secret")),
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rec recorder
+			h := newTestHandler(t, rec.handle, nil)
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newRequest(tt.body, tt.signature))
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if n := len(rec.get()); n != 0 {
+				t.Errorf("callback fired %d times, want 0", n)
+			}
+		})
+	}
+}
+
+func TestHandler_RejectsMalformedRequests(t *testing.T) {
+	tests := []struct {
+		name       string
+		newReq     func() *http.Request
+		wantStatus int
+	}{
+		{
+			name:       "non-POST",
+			newReq:     func() *http.Request { return httptest.NewRequest(http.MethodGet, "/webhooks", http.NoBody) },
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "invalid JSON",
+			newReq:     func() *http.Request { return newRequest(`{not json`, new(testSignature)) },
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "entityId of an unexpected JSON type",
+			newReq:     func() *http.Request { return newRequest(`{"eventId":"e","entityId":true}`, new(testSignature)) },
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "oversized body",
+			newReq: func() *http.Request {
+				return newRequest(`{"eventId":"`+strings.Repeat("A", maxBodyBytes)+`"}`, new(testSignature))
+			},
+			wantStatus: http.StatusRequestEntityTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rec recorder
+			h := newTestHandler(t, rec.handle, nil)
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, tt.newReq())
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+			if n := len(rec.get()); n != 0 {
+				t.Errorf("callback fired %d times, want 0", n)
+			}
+		})
+	}
+}
+
+func TestHandler_MethodNotAllowedAdvertisesPOST(t *testing.T) {
+	h := newTestHandler(t, func(context.Context, Event) {}, nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/webhooks", http.NoBody))
+
+	if got := w.Header().Get("Allow"); got != http.MethodPost {
+		t.Errorf("Allow = %q, want %q", got, http.MethodPost)
+	}
+}
+
+func TestHandler_MaxAge(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxAge       time.Duration
+		eventCreated int64
+		wantCalls    int
+	}{
+		{"fresh event within window", time.Hour, testEventCreated - 60, 1},
+		{"event exactly at the window edge", time.Hour, testEventCreated - int64(time.Hour.Seconds()), 1},
+		{"stale event outside window", time.Hour, testEventCreated - 7200, 0},
+		{"zero MaxAge accepts an ancient event", 0, 1, 1},
+		// Clock skew: an event stamped slightly in the future has a negative age,
+		// which must not read as stale.
+		{"event from the near future", time.Hour, testEventCreated + 60, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rec recorder
+			h := newTestHandler(t, rec.handle, &Options{MaxAge: tt.maxAge})
+
+			body := fmt.Sprintf(`{"eventId":%q,"eventCreated":%d,"storeId":1003,"entityId":1,"eventType":"product.created"}`, testEventID, tt.eventCreated)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newRequest(body, nil))
+
+			// A stale event is authentic, so it is still answered with success:
+			// failing it would only earn 27 retries of an event we will not process.
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+			if n := len(rec.get()); n != tt.wantCalls {
+				t.Errorf("callback fired %d times, want %d", n, tt.wantCalls)
+			}
+		})
+	}
+}
+
+func TestHandler_Deduper(t *testing.T) {
+	var rec recorder
+	dd := &mapDeduper{}
+	h := newTestHandler(t, rec.handle, &Options{Deduper: dd})
+
+	// The same signed event replayed: valid every time, since the signature never
+	// expires. Only the first delivery should reach the callback.
+	for range 3 {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, newRequest(orderCreatedBody, nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+	}
+
+	if n := len(rec.get()); n != 1 {
+		t.Errorf("callback fired %d times for a replayed event, want 1", n)
+	}
+}
+
+// A broken dedupe store must not swallow events: delivery is at-least-once
+// anyway, so failing open costs a duplicate while failing closed loses data.
+func TestHandler_DeduperErrorFailsOpen(t *testing.T) {
+	var rec recorder
+	var reported []error
+	dd := &mapDeduper{err: errors.New("store unavailable")}
+	h := newTestHandler(t, rec.handle, &Options{
+		Deduper: dd,
+		OnError: func(_ *http.Request, err error) { reported = append(reported, err) },
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newRequest(orderCreatedBody, nil))
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if n := len(rec.get()); n != 1 {
+		t.Errorf("callback fired %d times, want 1", n)
+	}
+	if len(reported) != 1 {
+		t.Fatalf("OnError called %d times, want 1", len(reported))
+	}
+	if !strings.Contains(reported[0].Error(), "store unavailable") {
+		t.Errorf("OnError got %v, want it to wrap the store error", reported[0])
+	}
+}
+
+func TestHandler_OnErrorNeverLeaksSecrets(t *testing.T) {
+	var reported []error
+	h := newTestHandler(t, func(context.Context, Event) {}, &Options{
+		OnError: func(_ *http.Request, err error) { reported = append(reported, err) },
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newRequest(orderCreatedBody, new("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")))
+
+	if len(reported) != 1 {
+		t.Fatalf("OnError called %d times, want 1", len(reported))
+	}
+	if msg := reported[0].Error(); strings.Contains(msg, testSecret) {
+		t.Errorf("OnError message contains the client secret: %s", msg)
+	}
+	// The response body must not describe why verification failed.
+	if body := w.Body.String(); strings.Contains(body, "signature") {
+		t.Errorf("response body leaks failure detail: %s", body)
+	}
+}
+
+func TestHandler_SuccessCode(t *testing.T) {
+	for _, code := range successCodes {
+		t.Run(fmt.Sprint(code), func(t *testing.T) {
+			var rec recorder
+			h := newTestHandler(t, rec.handle, &Options{SuccessCode: code})
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newRequest(orderCreatedBody, nil))
+
+			if w.Code != code {
+				t.Errorf("status = %d, want %d", w.Code, code)
+			}
+			if n := len(rec.get()); n != 1 {
+				t.Errorf("callback fired %d times, want 1", n)
+			}
+		})
+	}
+}
+
+// Ecwid counts 203, 208 and every 3xx as a failed delivery despite 203/208 being
+// 2xx. Configuring one is a silent outage, so it must not be accepted.
+func TestNewHandler_RejectsCodesEcwidTreatsAsFailure(t *testing.T) {
+	for _, code := range []int{203, 208, 301, 302, 400, 500, 999, -1} {
+		if _, err := NewHandler(testSecret, func(context.Context, Event) {}, &Options{SuccessCode: code}); err == nil {
+			t.Errorf("NewHandler(SuccessCode: %d) = nil, want an error", code)
+		}
+	}
+}
+
+func TestNewHandler_Validation(t *testing.T) {
+	tests := []struct {
+		name         string
+		clientSecret string
+		handle       func(context.Context, Event)
+		opts         *Options
+	}{
+		{"empty client secret", "", func(context.Context, Event) {}, nil},
+		{"nil callback", testSecret, nil, nil},
+		{"negative MaxAge", testSecret, func(context.Context, Event) {}, &Options{MaxAge: -time.Second}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := NewHandler(tt.clientSecret, tt.handle, tt.opts); err == nil {
+				t.Error("NewHandler() = nil, want an error")
+			}
+		})
+	}
+}
+
+func TestNewHandler_NilOptionsDefaultsTo200(t *testing.T) {
+	h, err := NewHandler(testSecret, func(context.Context, Event) {}, nil)
+	if err != nil {
+		t.Fatalf("NewHandler() = %v", err)
+	}
+	if h.successCode != http.StatusOK {
+		t.Errorf("successCode = %d, want %d", h.successCode, http.StatusOK)
+	}
+}
+
+// The response must reach Ecwid before the callback runs, or a slow callback
+// trips Ecwid's 10s response timeout and earns a redelivery.
+func TestHandler_RespondsBeforeCallback(t *testing.T) {
+	responded := make(chan struct{})
+	release := make(chan struct{})
+
+	h, err := NewHandler(testSecret, func(context.Context, Event) {
+		// Blocks until the client has read the response. If the handler waited
+		// for this callback before responding, the test would deadlock.
+		<-responded
+		close(release)
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewHandler() = %v", err)
+	}
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader(orderCreatedBody))
+	if err != nil {
+		t.Fatalf("NewRequest() = %v", err)
+	}
+	req.Header.Set(SignatureHeader, sign(testEventCreated, testEventID, testSecret))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	close(responded)
+
+	select {
+	case <-release:
+	case <-time.After(5 * time.Second):
+		t.Fatal("callback did not run after the response was sent")
+	}
+}
+
+// The callback outlives the request context, which is canceled once ServeHTTP
+// returns and may be cut short by Ecwid closing the connection.
+func TestHandler_CallbackContextNotCanceled(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		ctxErr error
+	)
+	done := make(chan struct{})
+
+	h, err := NewHandler(testSecret, func(ctx context.Context, _ Event) {
+		mu.Lock()
+		ctxErr = ctx.Err()
+		mu.Unlock()
+		close(done)
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewHandler() = %v", err)
+	}
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader(orderCreatedBody))
+	if err != nil {
+		t.Fatalf("NewRequest() = %v", err)
+	}
+	req.Header.Set(SignatureHeader, sign(testEventCreated, testEventID, testSecret))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do() = %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("callback never ran")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if ctxErr != nil {
+		t.Errorf("callback context was canceled: %v", ctxErr)
+	}
+}
+
+func TestHandler_ConcurrentDeliveries(t *testing.T) {
+	var rec recorder
+	dd := &mapDeduper{}
+	h := newTestHandler(t, rec.handle, &Options{Deduper: dd})
+
+	const n = 20
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Go(func() {
+			eventID := fmt.Sprintf("event-%d", i)
+			body := fmt.Sprintf(`{"eventId":%q,"eventCreated":%d,"storeId":1003,"entityId":%d,"eventType":"product.created"}`, eventID, testEventCreated, i)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newRequest(body, nil))
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := len(rec.get()); got != n {
+		t.Errorf("callback fired %d times, want %d", got, n)
+	}
+}

--- a/ecwid/webhooks/handler_test.go
+++ b/ecwid/webhooks/handler_test.go
@@ -496,6 +496,8 @@ func TestHandler_CallbackContextNotCanceled(t *testing.T) {
 	}
 }
 
+// Distinct events delivered at once must all get through: dedupe must suppress
+// replays without serializing or dropping unrelated traffic.
 func TestHandler_ConcurrentDeliveries(t *testing.T) {
 	var rec recorder
 	dd := &mapDeduper{}
@@ -518,5 +520,36 @@ func TestHandler_ConcurrentDeliveries(t *testing.T) {
 
 	if got := len(rec.get()); got != n {
 		t.Errorf("callback fired %d times, want %d", got, n)
+	}
+}
+
+// The same event replayed concurrently must reach the callback once. This is the
+// case a non-atomic Deduper — one that checks, then sets — lets slip, and the
+// reason [Deduper] requires the two to be a single step.
+func TestHandler_ConcurrentReplaysOfSameEvent(t *testing.T) {
+	var rec recorder
+	dd := &mapDeduper{}
+	h := newTestHandler(t, rec.handle, &Options{Deduper: dd})
+
+	// One signed body, delivered many times at once — exactly what an attacker
+	// replaying a captured webhook, or Ecwid retrying a slow delivery, produces.
+	const n = 20
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			<-start // Maximize overlap on the check-and-set.
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, newRequest(orderCreatedBody, nil))
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	if got := len(rec.get()); got != 1 {
+		t.Errorf("callback fired %d times for %d concurrent replays of one event, want 1", got, n)
 	}
 }

--- a/ecwid/webhooks/types.go
+++ b/ecwid/webhooks/types.go
@@ -1,0 +1,358 @@
+package webhooks
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+)
+
+// EventType identifies what happened in the store, in "entity.action" form.
+type EventType string
+
+// Store profile events. Require the read_store_profile scope.
+const (
+	EventProfileUpdated                   EventType = "profile.updated"
+	EventProfileSubscriptionStatusChanged EventType = "profile.subscriptionStatusChanged"
+	EventProfilePersonalDataRemovalReq    EventType = "profile.personalDataRemovalRequest"
+	EventProfilePersonalDataExportReq     EventType = "profile.personalDataExportRequest"
+)
+
+// Order events. Require the read_orders scope.
+const (
+	EventOrderCreated EventType = "order.created"
+	EventOrderUpdated EventType = "order.updated"
+	EventOrderDeleted EventType = "order.deleted"
+)
+
+// Abandoned cart events. Require the read_orders scope.
+const (
+	EventUnfinishedOrderCreated EventType = "unfinished_order.created"
+	EventUnfinishedOrderUpdated EventType = "unfinished_order.updated"
+	EventUnfinishedOrderDeleted EventType = "unfinished_order.deleted"
+)
+
+// Product events. Require the read_catalog scope.
+const (
+	EventProductCreated EventType = "product.created"
+	EventProductUpdated EventType = "product.updated"
+	EventProductDeleted EventType = "product.deleted"
+)
+
+// Category events. Require the read_catalog scope.
+const (
+	EventCategoryCreated EventType = "category.created"
+	EventCategoryUpdated EventType = "category.updated"
+	EventCategoryDeleted EventType = "category.deleted"
+)
+
+// Product type (product class) events. Require the read_catalog scope.
+const (
+	EventProductClassCreated EventType = "product_class.created"
+	EventProductClassUpdated EventType = "product_class.updated"
+	EventProductClassDeleted EventType = "product_class.deleted"
+)
+
+// Customer events. Require the read_customers scope.
+const (
+	EventCustomerCreated EventType = "customer.created"
+	EventCustomerUpdated EventType = "customer.updated"
+	EventCustomerDeleted EventType = "customer.deleted"
+)
+
+// Customer GDPR events. These require the read_store_profile scope, NOT
+// read_customers as the neighbouring customer.* events do.
+const (
+	EventCustomerPersonalDataRemovalReq EventType = "customer.personalDataRemovalRequest"
+	EventCustomerPersonalDataExportReq  EventType = "customer.personalDataExportRequest"
+)
+
+// Customer group events. Require the read_customers scope.
+const (
+	EventCustomerGroupCreated EventType = "customer_group.created"
+	EventCustomerGroupUpdated EventType = "customer_group.updated"
+	EventCustomerGroupDeleted EventType = "customer_group.deleted"
+)
+
+// Discount coupon events. Require the read_discount_coupons scope.
+const (
+	EventDiscountCouponCreated EventType = "discount_coupon.created"
+	EventDiscountCouponUpdated EventType = "discount_coupon.updated"
+	EventDiscountCouponDeleted EventType = "discount_coupon.deleted"
+)
+
+// Promotion (advanced discount) events. Require the read_promotion scope.
+const (
+	EventPromotionCreated EventType = "promotion.created"
+	EventPromotionUpdated EventType = "promotion.updated"
+	EventPromotionDeleted EventType = "promotion.deleted"
+)
+
+// Product review events. Require the read_reviews scope.
+const (
+	EventReviewCreated EventType = "review.created"
+	EventReviewUpdated EventType = "review.updated"
+	EventReviewDeleted EventType = "review.deleted"
+)
+
+// Order tax invoice events. Require the read_invoices scope. There is no
+// invoice.updated event.
+const (
+	EventInvoiceCreated EventType = "invoice.created"
+	EventInvoiceDeleted EventType = "invoice.deleted"
+)
+
+// Application events. Require the read_store_profile scope. They are delivered
+// only to the app they concern.
+const (
+	EventApplicationInstalled                 EventType = "application.installed"
+	EventApplicationUninstalled               EventType = "application.uninstalled"
+	EventApplicationSubscriptionStatusChanged EventType = "application.subscriptionStatusChanged"
+	EventApplicationStorageChanged            EventType = "application.storageChanged"
+)
+
+// applicationPrefix marks the event family whose entityId is sent as a quoted
+// JSON string rather than a number.
+const applicationPrefix = "application."
+
+// Event is a webhook delivered by Ecwid.
+//
+// Only EventCreated and EventID are covered by the signature; every other field
+// is unauthenticated. See the package documentation.
+type Event struct {
+	// EventID is a UUID, unique per webhook. Use it to dedupe replays and retries.
+	EventID string `json:"eventId"`
+	// EventCreated is the UNIX timestamp, in seconds, of when the event happened.
+	EventCreated int64 `json:"eventCreated"`
+	// StoreID is the Ecwid store ID.
+	StoreID int64 `json:"storeId"`
+	// EventType is the entity and action, e.g. [EventOrderCreated].
+	EventType EventType `json:"eventType"`
+	// EntityID identifies the affected item: order, product, customer, etc.
+	// Use it to re-fetch the entity over the REST API.
+	//
+	// It is normalized to a string because Ecwid does not type it consistently
+	// on the wire: order and product events send a JSON number
+	// (`"entityId":103878161`) while application.* events send a quoted string
+	// (`"entityId":"1003"`). Both decode into this field.
+	//
+	// For order events this is the *internal* order ID, which the REST API's
+	// order endpoints do not accept. The human-readable order ID is
+	// [OrderData.OrderID].
+	EntityID string `json:"entityId"`
+	// Data carries extra details for the events that have them, and is absent
+	// entirely for those that do not (product.*, category.*, discount_coupon.*,
+	// application.installed, application.uninstalled). Decode it with the
+	// accessor for the event family, e.g. [Event.OrderData].
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+// UnmarshalJSON decodes an Ecwid webhook body, accepting entityId as either a
+// JSON number or a quoted string and normalizing it to [Event.EntityID].
+func (e *Event) UnmarshalJSON(b []byte) error {
+	// alias sheds the methods on Event, so json does not recurse into this one.
+	type alias Event
+	aux := struct {
+		EntityID json.RawMessage `json:"entityId"`
+		*alias
+	}{alias: (*alias)(e)}
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	raw := bytes.TrimSpace(aux.EntityID)
+	switch {
+	case len(raw) == 0, bytes.Equal(raw, []byte("null")):
+		e.EntityID = ""
+	case raw[0] == '"':
+		if err := json.Unmarshal(raw, &e.EntityID); err != nil {
+			return fmt.Errorf("webhooks: decode entityId: %w", err)
+		}
+	case isJSONNumber(string(raw)):
+		e.EntityID = string(raw)
+	default:
+		return fmt.Errorf("webhooks: entityId must be a JSON string or number, got %s", raw)
+	}
+	return nil
+}
+
+// MarshalJSON encodes the event in Ecwid's wire format. It reproduces the
+// entityId typing quirk that [Event.UnmarshalJSON] absorbs: application.* events
+// get a quoted string, everything else a bare JSON number.
+func (e Event) MarshalJSON() ([]byte, error) {
+	entityID, err := json.Marshal(e.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("webhooks: encode entityId: %w", err)
+	}
+	if !strings.HasPrefix(string(e.EventType), applicationPrefix) && isJSONNumber(e.EntityID) {
+		entityID = []byte(e.EntityID)
+	}
+
+	type alias Event
+	return json.Marshal(struct {
+		EntityID json.RawMessage `json:"entityId"`
+		*alias
+	}{EntityID: entityID, alias: (*alias)(&e)})
+}
+
+// isJSONNumber reports whether s is exactly one JSON number literal.
+func isJSONNumber(s string) bool {
+	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber()
+	tok, err := dec.Token()
+	if err != nil {
+		return false
+	}
+	if _, ok := tok.(json.Number); !ok {
+		return false
+	}
+	// Reject trailing junk, e.g. "1 2".
+	_, err = dec.Token()
+	return errors.Is(err, io.EOF)
+}
+
+// OrderData is the data payload of order.* events.
+type OrderData struct {
+	// OrderID is the human-readable order ID, e.g. "XJ12H" — the one the REST
+	// API's order endpoints accept, unlike [Event.EntityID].
+	OrderID string `json:"orderId"`
+	// OldPaymentStatus is absent on order.created and order.deleted.
+	OldPaymentStatus string `json:"oldPaymentStatus,omitempty"`
+	// NewPaymentStatus is absent on order.deleted.
+	NewPaymentStatus string `json:"newPaymentStatus,omitempty"`
+	// OldFulfillmentStatus is absent on order.created and order.deleted.
+	OldFulfillmentStatus string `json:"oldFulfillmentStatus,omitempty"`
+	// NewFulfillmentStatus is absent on order.deleted.
+	NewFulfillmentStatus string `json:"newFulfillmentStatus,omitempty"`
+}
+
+// UnfinishedOrderData is the data payload of unfinished_order.* events.
+type UnfinishedOrderData struct {
+	// OrderID is the human-readable order ID, e.g. "RA1SD".
+	OrderID string `json:"orderId"`
+	// CartID is the UUID of the abandoned cart.
+	CartID string `json:"cartId"`
+}
+
+// ReviewData is the data payload of review.* events.
+type ReviewData struct {
+	// ProductID is the reviewed product.
+	ProductID int64 `json:"productId"`
+	// OrderID is the internal order ID as a number — unlike [OrderData.OrderID]
+	// and [InvoiceData.OrderID], which are the human-readable string form.
+	OrderID int64 `json:"orderId"`
+	// Status is "MODERATED" or "PUBLISHED", and is absent on review.deleted.
+	Status string `json:"status,omitempty"`
+}
+
+// CustomerData is the data payload of customer.* events.
+type CustomerData struct {
+	CustomerEmail string `json:"customerEmail"`
+}
+
+// PromotionData is the data payload of promotion.* events.
+type PromotionData struct {
+	// Version is Ecwid's internal iterated version of the discount.
+	Version int `json:"version"`
+}
+
+// InvoiceData is the data payload of invoice.* events.
+type InvoiceData struct {
+	// OrderID is the human-readable ID of the invoiced order, e.g. "GH781".
+	OrderID string `json:"orderId"`
+}
+
+// AppSubscriptionData is the data payload of application.subscriptionStatusChanged.
+//
+// Note the asymmetry with the similarly named
+// [ProfileSubscriptionData]: this event reports a subscription *status*
+// (e.g. "TRIAL" to "ACTIVE"), that one a subscription *name*.
+type AppSubscriptionData struct {
+	OldSubscriptionStatus string `json:"oldSubscriptionStatus"`
+	NewSubscriptionStatus string `json:"newSubscriptionStatus"`
+}
+
+// ProfileSubscriptionData is the data payload of profile.subscriptionStatusChanged.
+//
+// Note the asymmetry with the similarly named [AppSubscriptionData]: this event
+// reports a subscription *name* (e.g. "ECWID_BUSINESS" to "ECWID_UNLIMITED"),
+// that one a subscription *status*.
+type ProfileSubscriptionData struct {
+	OldSubscriptionName string `json:"oldSubscriptionName"`
+	NewSubscriptionName string `json:"newSubscriptionName"`
+}
+
+// OrderData decodes the payload of an order.* event.
+func (e Event) OrderData() (OrderData, error) {
+	var d OrderData
+	err := e.decodeData(&d, EventOrderCreated, EventOrderUpdated, EventOrderDeleted)
+	return d, err
+}
+
+// UnfinishedOrderData decodes the payload of an unfinished_order.* event.
+func (e Event) UnfinishedOrderData() (UnfinishedOrderData, error) {
+	var d UnfinishedOrderData
+	err := e.decodeData(&d, EventUnfinishedOrderCreated, EventUnfinishedOrderUpdated, EventUnfinishedOrderDeleted)
+	return d, err
+}
+
+// ReviewData decodes the payload of a review.* event.
+func (e Event) ReviewData() (ReviewData, error) {
+	var d ReviewData
+	err := e.decodeData(&d, EventReviewCreated, EventReviewUpdated, EventReviewDeleted)
+	return d, err
+}
+
+// CustomerData decodes the payload of a customer.* event.
+func (e Event) CustomerData() (CustomerData, error) {
+	var d CustomerData
+	err := e.decodeData(&d, EventCustomerCreated, EventCustomerUpdated, EventCustomerDeleted)
+	return d, err
+}
+
+// PromotionData decodes the payload of a promotion.* event.
+func (e Event) PromotionData() (PromotionData, error) {
+	var d PromotionData
+	err := e.decodeData(&d, EventPromotionCreated, EventPromotionUpdated, EventPromotionDeleted)
+	return d, err
+}
+
+// InvoiceData decodes the payload of an invoice.* event.
+func (e Event) InvoiceData() (InvoiceData, error) {
+	var d InvoiceData
+	err := e.decodeData(&d, EventInvoiceCreated, EventInvoiceDeleted)
+	return d, err
+}
+
+// AppSubscriptionData decodes the payload of application.subscriptionStatusChanged.
+func (e Event) AppSubscriptionData() (AppSubscriptionData, error) {
+	var d AppSubscriptionData
+	err := e.decodeData(&d, EventApplicationSubscriptionStatusChanged)
+	return d, err
+}
+
+// ProfileSubscriptionData decodes the payload of profile.subscriptionStatusChanged.
+func (e Event) ProfileSubscriptionData() (ProfileSubscriptionData, error) {
+	var d ProfileSubscriptionData
+	err := e.decodeData(&d, EventProfileSubscriptionStatusChanged)
+	return d, err
+}
+
+// decodeData unmarshals Data into dst, refusing event types that do not carry
+// that payload so a caller cannot silently read a zero value off the wrong event.
+func (e Event) decodeData(dst any, allowed ...EventType) error {
+	if !slices.Contains(allowed, e.EventType) {
+		return fmt.Errorf("webhooks: event type %q carries no such data (want one of %v)", e.EventType, allowed)
+	}
+	if len(e.Data) == 0 || bytes.Equal(bytes.TrimSpace(e.Data), []byte("null")) {
+		return fmt.Errorf("webhooks: event %q has no data", e.EventType)
+	}
+	if err := json.Unmarshal(e.Data, dst); err != nil {
+		return fmt.Errorf("webhooks: decode %q data: %w", e.EventType, err)
+	}
+	return nil
+}

--- a/ecwid/webhooks/types_test.go
+++ b/ecwid/webhooks/types_test.go
@@ -1,0 +1,448 @@
+package webhooks
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// allEventTypes is every event this package defines. Payloads below are the
+// documented examples with Ecwid's JavaScript-style comments and trailing commas
+// removed — their docs' snippets are not valid JSON as printed.
+var allEventTypes = []EventType{
+	EventProfileUpdated,
+	EventProfileSubscriptionStatusChanged,
+	EventProfilePersonalDataRemovalReq,
+	EventProfilePersonalDataExportReq,
+	EventOrderCreated,
+	EventOrderUpdated,
+	EventOrderDeleted,
+	EventUnfinishedOrderCreated,
+	EventUnfinishedOrderUpdated,
+	EventUnfinishedOrderDeleted,
+	EventProductCreated,
+	EventProductUpdated,
+	EventProductDeleted,
+	EventCategoryCreated,
+	EventCategoryUpdated,
+	EventCategoryDeleted,
+	EventProductClassCreated,
+	EventProductClassUpdated,
+	EventProductClassDeleted,
+	EventCustomerCreated,
+	EventCustomerUpdated,
+	EventCustomerDeleted,
+	EventCustomerPersonalDataRemovalReq,
+	EventCustomerPersonalDataExportReq,
+	EventCustomerGroupCreated,
+	EventCustomerGroupUpdated,
+	EventCustomerGroupDeleted,
+	EventDiscountCouponCreated,
+	EventDiscountCouponUpdated,
+	EventDiscountCouponDeleted,
+	EventPromotionCreated,
+	EventPromotionUpdated,
+	EventPromotionDeleted,
+	EventReviewCreated,
+	EventReviewUpdated,
+	EventReviewDeleted,
+	EventInvoiceCreated,
+	EventInvoiceDeleted,
+	EventApplicationInstalled,
+	EventApplicationUninstalled,
+	EventApplicationSubscriptionStatusChanged,
+	EventApplicationStorageChanged,
+}
+
+func TestEventTypes_AllDefined(t *testing.T) {
+	const want = 42
+	if len(allEventTypes) != want {
+		t.Errorf("allEventTypes has %d entries, want %d", len(allEventTypes), want)
+	}
+
+	seen := make(map[EventType]bool, len(allEventTypes))
+	for _, et := range allEventTypes {
+		if seen[et] {
+			t.Errorf("duplicate event type %q", et)
+		}
+		seen[et] = true
+
+		entity, action, ok := strings.Cut(string(et), ".")
+		if !ok || entity == "" || action == "" {
+			t.Errorf("event type %q is not in entity.action form", et)
+		}
+	}
+
+	// Ecwid publishes no invoice.updated, and inventing one would have callers
+	// switch on an event that never arrives.
+	if seen["invoice.updated"] {
+		t.Error("invoice.updated is defined, but Ecwid has no such event")
+	}
+}
+
+func TestEvent_UnmarshalEntityID(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantEntityID string
+		wantType     EventType
+	}{
+		{
+			// Order and product events send entityId as a bare JSON number.
+			name: "numeric entityId (order.created)",
+			body: `{
+				"eventId":"80aece08-40e8-4145-8764-6c2f0d38678",
+				"eventCreated":1234567,
+				"storeId":1003,
+				"entityId":103878161,
+				"eventType":"order.created",
+				"data":{"orderId":"XJ12H","newPaymentStatus":"PAID","newFulfillmentStatus":"SHIPPED"}
+			}`,
+			wantEntityID: "103878161",
+			wantType:     EventOrderCreated,
+		},
+		{
+			// application.* events send the same field as a quoted string.
+			name: "string entityId (application.installed)",
+			body: `{
+				"eventId":"80aece08-40e8-4145-8764-6c2f0d38678",
+				"eventCreated":1234567,
+				"storeId":1003,
+				"entityId":"1003",
+				"eventType":"application.installed"
+			}`,
+			wantEntityID: "1003",
+			wantType:     EventApplicationInstalled,
+		},
+		{
+			name: "entityId exceeding float64 precision keeps every digit",
+			body: `{"eventId":"e","eventCreated":1,"storeId":1003,"entityId":9007199254740993,"eventType":"product.updated"}`,
+			// Decoding via float64 would round this to ...92.
+			wantEntityID: "9007199254740993",
+			wantType:     EventProductUpdated,
+		},
+		{
+			name:         "absent entityId",
+			body:         `{"eventId":"e","eventCreated":1,"storeId":1003,"eventType":"product.updated"}`,
+			wantEntityID: "",
+			wantType:     EventProductUpdated,
+		},
+		{
+			name:         "null entityId",
+			body:         `{"eventId":"e","eventCreated":1,"storeId":1003,"entityId":null,"eventType":"product.updated"}`,
+			wantEntityID: "",
+			wantType:     EventProductUpdated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e Event
+			if err := json.Unmarshal([]byte(tt.body), &e); err != nil {
+				t.Fatalf("Unmarshal() = %v, want nil", err)
+			}
+			if e.EntityID != tt.wantEntityID {
+				t.Errorf("EntityID = %q, want %q", e.EntityID, tt.wantEntityID)
+			}
+			if e.EventType != tt.wantType {
+				t.Errorf("EventType = %q, want %q", e.EventType, tt.wantType)
+			}
+		})
+	}
+}
+
+func TestEvent_UnmarshalEntityID_Invalid(t *testing.T) {
+	for _, body := range []string{
+		`{"eventId":"e","entityId":true,"eventType":"product.updated"}`,
+		`{"eventId":"e","entityId":{"id":1},"eventType":"product.updated"}`,
+		`{"eventId":"e","entityId":[1],"eventType":"product.updated"}`,
+	} {
+		var e Event
+		if err := json.Unmarshal([]byte(body), &e); err == nil {
+			t.Errorf("Unmarshal(%s) = nil, want an error", body)
+		}
+	}
+}
+
+func TestEvent_UnmarshalCommonFields(t *testing.T) {
+	const body = `{
+		"eventId":"95ed494f-362d-4fca-933d-f5c7064b04bb",
+		"eventCreated":1634209655,
+		"storeId":1003,
+		"entityId":293225803,
+		"eventType":"unfinished_order.created",
+		"data":{"orderId":"RA1SD","cartId":"320AB5DE-5EA6-4419-A4CF-0B04D2913190"}
+	}`
+
+	var e Event
+	if err := json.Unmarshal([]byte(body), &e); err != nil {
+		t.Fatalf("Unmarshal() = %v, want nil", err)
+	}
+	if e.EventID != "95ed494f-362d-4fca-933d-f5c7064b04bb" {
+		t.Errorf("EventID = %q", e.EventID)
+	}
+	if e.EventCreated != 1634209655 {
+		t.Errorf("EventCreated = %d, want 1634209655", e.EventCreated)
+	}
+	if e.StoreID != 1003 {
+		t.Errorf("StoreID = %d, want 1003", e.StoreID)
+	}
+}
+
+// product.*, category.* and discount_coupon.* omit the data key entirely.
+func TestEvent_NoDataKey(t *testing.T) {
+	for _, body := range []string{
+		`{"eventId":"08a78904-4c1a-0aa0-953a-2e33c56236f1","eventCreated":1469429915,"storeId":1003,"entityId":667251253,"eventType":"product.created"}`,
+		`{"eventId":"08a78904-0aa0-4c1a-953a-2e33c56236f0","eventCreated":1469429912,"storeId":1003,"entityId":66722483,"eventType":"category.created"}`,
+		`{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":7891234567,"storeId":1003,"entityId":12345678,"eventType":"discount_coupon.created"}`,
+		`{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":1234567,"storeId":1003,"entityId":"1003","eventType":"application.uninstalled"}`,
+	} {
+		var e Event
+		if err := json.Unmarshal([]byte(body), &e); err != nil {
+			t.Errorf("Unmarshal(%s) = %v, want nil", body, err)
+			continue
+		}
+		if e.Data != nil {
+			t.Errorf("Data = %s, want nil for %s", e.Data, e.EventType)
+		}
+	}
+}
+
+func TestEvent_DataAccessors(t *testing.T) {
+	// Each body is the documented example for that event.
+	t.Run("order.created", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":1234567,"storeId":1003,"entityId":103878161,"eventType":"order.created","data":{"orderId":"XJ12H","newPaymentStatus":"PAID","newFulfillmentStatus":"SHIPPED"}}`)
+		d, err := e.OrderData()
+		if err != nil {
+			t.Fatalf("OrderData() = %v", err)
+		}
+		want := OrderData{OrderID: "XJ12H", NewPaymentStatus: "PAID", NewFulfillmentStatus: "SHIPPED"}
+		if d != want {
+			t.Errorf("OrderData() = %+v, want %+v", d, want)
+		}
+		// entityId is the internal ID; the usable one lives in data.
+		if e.EntityID == d.OrderID {
+			t.Error("EntityID and data.orderId should differ for order events")
+		}
+	})
+
+	t.Run("order.updated", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":1234567,"storeId":1003,"entityId":450012387,"eventType":"order.updated","data":{"orderId":"B8HGD","oldPaymentStatus":"PAID","newPaymentStatus":"PAID","oldFulfillmentStatus":"PROCESSING","newFulfillmentStatus":"SHIPPED"}}`)
+		d, err := e.OrderData()
+		if err != nil {
+			t.Fatalf("OrderData() = %v", err)
+		}
+		want := OrderData{
+			OrderID:              "B8HGD",
+			OldPaymentStatus:     "PAID",
+			NewPaymentStatus:     "PAID",
+			OldFulfillmentStatus: "PROCESSING",
+			NewFulfillmentStatus: "SHIPPED",
+		}
+		if d != want {
+			t.Errorf("OrderData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("order.deleted", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":1234567,"storeId":1003,"entityId":103878161,"eventType":"order.deleted","data":{"orderId":"XJ12H"}}`)
+		d, err := e.OrderData()
+		if err != nil {
+			t.Fatalf("OrderData() = %v", err)
+		}
+		if want := (OrderData{OrderID: "XJ12H"}); d != want {
+			t.Errorf("OrderData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("unfinished_order.created", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"95ed494f-362d-4fca-933d-f5c7064b04bb","eventCreated":1634209655,"storeId":1003,"entityId":293225803,"eventType":"unfinished_order.created","data":{"orderId":"RA1SD","cartId":"320AB5DE-5EA6-4419-A4CF-0B04D2913190"}}`)
+		d, err := e.UnfinishedOrderData()
+		if err != nil {
+			t.Fatalf("UnfinishedOrderData() = %v", err)
+		}
+		want := UnfinishedOrderData{OrderID: "RA1SD", CartID: "320AB5DE-5EA6-4419-A4CF-0B04D2913190"}
+		if d != want {
+			t.Errorf("UnfinishedOrderData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("review.created", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"95ed494f-362d-4fca-933d-f5c7064b04bb","eventCreated":1634209655,"storeId":1003,"entityId":293225803,"eventType":"review.created","data":{"productId":62752,"orderId":63254,"status":"MODERATED"}}`)
+		d, err := e.ReviewData()
+		if err != nil {
+			t.Fatalf("ReviewData() = %v", err)
+		}
+		// review's orderId is a number, unlike order.*/invoice.*'s string form.
+		want := ReviewData{ProductID: 62752, OrderID: 63254, Status: "MODERATED"}
+		if d != want {
+			t.Errorf("ReviewData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("review.deleted has no status", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"95ed494f-362d-4fca-933d-f5c7064b04bb","eventCreated":1634209655,"storeId":1003,"entityId":293225803,"eventType":"review.deleted","data":{"productId":62752,"orderId":63254}}`)
+		d, err := e.ReviewData()
+		if err != nil {
+			t.Fatalf("ReviewData() = %v", err)
+		}
+		if want := (ReviewData{ProductID: 62752, OrderID: 63254}); d != want {
+			t.Errorf("ReviewData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("customer.created", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":7891234567,"storeId":1003,"entityId":1663830,"eventType":"customer.created","data":{"customerEmail":"user@example.com"}}`)
+		d, err := e.CustomerData()
+		if err != nil {
+			t.Fatalf("CustomerData() = %v", err)
+		}
+		if want := (CustomerData{CustomerEmail: "user@example.com"}); d != want {
+			t.Errorf("CustomerData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("promotion.created", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"95ed494f-362d-4fca-933d-f5c7064b04bb","eventCreated":1469429915,"storeId":1003,"entityId":667251253,"eventType":"promotion.created","data":{"version":1}}`)
+		d, err := e.PromotionData()
+		if err != nil {
+			t.Fatalf("PromotionData() = %v", err)
+		}
+		if want := (PromotionData{Version: 1}); d != want {
+			t.Errorf("PromotionData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("invoice.created", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"08a78904-4c1a-0aa0-953a-2e33c56236f1","eventCreated":1469429915,"storeId":1003,"entityId":667251253,"eventType":"invoice.created","data":{"orderId":"GH781"}}`)
+		d, err := e.InvoiceData()
+		if err != nil {
+			t.Fatalf("InvoiceData() = %v", err)
+		}
+		if want := (InvoiceData{OrderID: "GH781"}); d != want {
+			t.Errorf("InvoiceData() = %+v, want %+v", d, want)
+		}
+	})
+
+	// The two subscriptionStatusChanged events look alike but use different keys.
+	t.Run("application.subscriptionStatusChanged uses status", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":1234567,"storeId":1003,"entityId":"1003","eventType":"application.subscriptionStatusChanged","data":{"oldSubscriptionStatus":"TRIAL","newSubscriptionStatus":"ACTIVE"}}`)
+		d, err := e.AppSubscriptionData()
+		if err != nil {
+			t.Fatalf("AppSubscriptionData() = %v", err)
+		}
+		want := AppSubscriptionData{OldSubscriptionStatus: "TRIAL", NewSubscriptionStatus: "ACTIVE"}
+		if d != want {
+			t.Errorf("AppSubscriptionData() = %+v, want %+v", d, want)
+		}
+	})
+
+	t.Run("profile.subscriptionStatusChanged uses name", func(t *testing.T) {
+		e := mustUnmarshal(t, `{"eventId":"80aece08-40e8-4145-8764-6c2f0d38678","eventCreated":1494503041,"storeId":1421002,"entityId":1421002,"eventType":"profile.subscriptionStatusChanged","data":{"oldSubscriptionName":"ECWID_BUSINESS","newSubscriptionName":"ECWID_UNLIMITED"}}`)
+		d, err := e.ProfileSubscriptionData()
+		if err != nil {
+			t.Fatalf("ProfileSubscriptionData() = %v", err)
+		}
+		want := ProfileSubscriptionData{OldSubscriptionName: "ECWID_BUSINESS", NewSubscriptionName: "ECWID_UNLIMITED"}
+		if d != want {
+			t.Errorf("ProfileSubscriptionData() = %+v, want %+v", d, want)
+		}
+	})
+}
+
+// An accessor must not hand back a zero value for an event that never carries
+// that payload — silently reading data.orderId off a product event is exactly
+// the bug typed accessors exist to prevent.
+func TestEvent_DataAccessors_WrongEventType(t *testing.T) {
+	e := mustUnmarshal(t, `{"eventId":"e","eventCreated":1,"storeId":1003,"entityId":667251253,"eventType":"product.created"}`)
+
+	if _, err := e.OrderData(); err == nil {
+		t.Error("OrderData() on product.created = nil, want an error")
+	}
+	if _, err := e.ReviewData(); err == nil {
+		t.Error("ReviewData() on product.created = nil, want an error")
+	}
+	if _, err := e.AppSubscriptionData(); err == nil {
+		t.Error("AppSubscriptionData() on product.created = nil, want an error")
+	}
+
+	// Right family, but this member carries no data.
+	app := mustUnmarshal(t, `{"eventId":"e","eventCreated":1,"storeId":1003,"entityId":"1003","eventType":"application.installed"}`)
+	if _, err := app.AppSubscriptionData(); err == nil {
+		t.Error("AppSubscriptionData() on application.installed = nil, want an error")
+	}
+}
+
+// Marshal must reproduce the wire format it parses, so an Event round-trips and
+// a mock sender emits what Ecwid really sends.
+func TestEvent_MarshalJSON_EntityIDShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		event    Event
+		want     string
+		wantType EventType
+	}{
+		{
+			name:  "order event emits a bare number",
+			event: Event{EventID: "e", EventCreated: 1234567, StoreID: 1003, EventType: EventOrderCreated, EntityID: "103878161"},
+			want:  `"entityId":103878161`,
+		},
+		{
+			name:  "application event emits a quoted string",
+			event: Event{EventID: "e", EventCreated: 1234567, StoreID: 1003, EventType: EventApplicationInstalled, EntityID: "1003"},
+			want:  `"entityId":"1003"`,
+		},
+		{
+			name:  "non-numeric entityId stays quoted",
+			event: Event{EventID: "e", EventCreated: 1, StoreID: 1003, EventType: EventProductCreated, EntityID: "abc"},
+			want:  `"entityId":"abc"`,
+		},
+		{
+			name:  "empty entityId stays quoted rather than emitting invalid JSON",
+			event: Event{EventID: "e", EventCreated: 1, StoreID: 1003, EventType: EventProductCreated},
+			want:  `"entityId":""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.Marshal(tt.event)
+			if err != nil {
+				t.Fatalf("Marshal() = %v", err)
+			}
+			if !strings.Contains(string(b), tt.want) {
+				t.Errorf("Marshal() = %s, want it to contain %s", b, tt.want)
+			}
+
+			var got Event
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("Unmarshal(Marshal()) = %v", err)
+			}
+			if got.EntityID != tt.event.EntityID {
+				t.Errorf("round-tripped EntityID = %q, want %q", got.EntityID, tt.event.EntityID)
+			}
+			if got.EventType != tt.event.EventType {
+				t.Errorf("round-tripped EventType = %q, want %q", got.EventType, tt.event.EventType)
+			}
+		})
+	}
+}
+
+func TestEvent_MarshalJSON_OmitsAbsentData(t *testing.T) {
+	b, err := json.Marshal(Event{EventID: "e", EventCreated: 1, StoreID: 1003, EventType: EventProductCreated, EntityID: "1"})
+	if err != nil {
+		t.Fatalf("Marshal() = %v", err)
+	}
+	if strings.Contains(string(b), "data") {
+		t.Errorf("Marshal() = %s, want no data key", b)
+	}
+}
+
+func mustUnmarshal(t *testing.T, body string) Event {
+	t.Helper()
+	var e Event
+	if err := json.Unmarshal([]byte(body), &e); err != nil {
+		t.Fatalf("Unmarshal(%s) = %v", body, err)
+	}
+	return e
+}

--- a/ecwid/webhooks/verify.go
+++ b/ecwid/webhooks/verify.go
@@ -1,0 +1,66 @@
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// SignatureHeader is the HTTP header Ecwid sends the webhook signature in.
+const SignatureHeader = "X-Ecwid-Webhook-Signature"
+
+// ErrInvalidSignature reports that a webhook's signature was missing, malformed,
+// or did not match. Reject such a request; it is never a transient condition, so
+// a retry cannot fix it.
+var ErrInvalidSignature = errors.New("webhooks: invalid signature")
+
+// Verify checks an Ecwid webhook signature, returning nil only if it matches.
+//
+// The signature is base64(HMAC-SHA256(key = clientSecret, msg = "<eventCreated>.<eventID>")).
+// It covers ONLY those two values, not the request body — see the package
+// documentation for what that does and does not prove.
+//
+// Pass the app's client_secret as clientSecret. An access token (secret_*) is
+// the wrong key and will never verify.
+//
+// Verify fails closed: an empty signature is rejected, never skipped. Ecwid's own
+// PHP example does the opposite — it reads its $signatureHeaderPresent flag
+// before assigning it, so a request carrying no signature header at all skips
+// verification and is accepted. Do not reproduce that.
+func Verify(signature string, eventCreated int64, eventID, clientSecret string) error {
+	if clientSecret == "" {
+		return errors.New("webhooks: clientSecret must not be empty")
+	}
+	if signature == "" {
+		return fmt.Errorf("%w: no signature provided", ErrInvalidSignature)
+	}
+
+	got, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return fmt.Errorf("%w: not valid base64", ErrInvalidSignature)
+	}
+	if !hmac.Equal(got, mac(eventCreated, eventID, clientSecret)) {
+		return fmt.Errorf("%w: signature mismatch", ErrInvalidSignature)
+	}
+	return nil
+}
+
+// mac computes the raw HMAC-SHA256 of "<eventCreated>.<eventID>".
+func mac(eventCreated int64, eventID, clientSecret string) []byte {
+	h := hmac.New(sha256.New, []byte(clientSecret))
+	// Writes to a hash.Hash are documented never to return an error.
+	h.Write(strconv.AppendInt(nil, eventCreated, 10))
+	h.Write([]byte("."))
+	h.Write([]byte(eventID))
+	return h.Sum(nil)
+}
+
+// sign produces the signature Verify expects. Kept unexported: real callers only
+// ever verify, and an exported signer would invite using this package to forge
+// the very events it exists to authenticate.
+func sign(eventCreated int64, eventID, clientSecret string) string {
+	return base64.StdEncoding.EncodeToString(mac(eventCreated, eventID, clientSecret))
+}

--- a/ecwid/webhooks/verify_test.go
+++ b/ecwid/webhooks/verify_test.go
@@ -1,0 +1,142 @@
+package webhooks
+
+import (
+	"errors"
+	"testing"
+)
+
+// Known-good vector, computed independently of this package's own signing code:
+//
+//	printf '1234567.80aece08-40e8-4145-8764-6c2f0d38678' |
+//	  openssl dgst -sha256 -hmac 'test_client_secret' -binary | base64
+const (
+	testSecret       = "test_client_secret"
+	testEventID      = "80aece08-40e8-4145-8764-6c2f0d38678"
+	testEventCreated = int64(1234567)
+	testSignature    = "ekmGPQc/IpCwO6woAiM+L8uvY6chew4n6JVQCiDrEVw="
+)
+
+func TestVerify_KnownGoodVector(t *testing.T) {
+	if err := Verify(testSignature, testEventCreated, testEventID, testSecret); err != nil {
+		t.Fatalf("Verify() on known-good vector = %v, want nil", err)
+	}
+}
+
+// The signature covers "<eventCreated>.<eventID>" and nothing else, so it must
+// not verify once either half is altered.
+func TestVerify_Rejects(t *testing.T) {
+	tests := []struct {
+		name                       string
+		signature                  string
+		eventCreated               int64
+		eventID, clientSecret      string
+		wantInvalidSignatureSentin bool
+	}{
+		{
+			name:                       "missing signature fails closed",
+			signature:                  "",
+			eventCreated:               testEventCreated,
+			eventID:                    testEventID,
+			clientSecret:               testSecret,
+			wantInvalidSignatureSentin: true,
+		},
+		{
+			name:                       "tampered signature",
+			signature:                  "Xkm GPQc/IpCwO6woAiM+L8uvY6chew4n6JVQCiDrEVw=",
+			eventCreated:               testEventCreated,
+			eventID:                    testEventID,
+			clientSecret:               testSecret,
+			wantInvalidSignatureSentin: true,
+		},
+		{
+			name:                       "valid base64 but wrong digest",
+			signature:                  "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+			eventCreated:               testEventCreated,
+			eventID:                    testEventID,
+			clientSecret:               testSecret,
+			wantInvalidSignatureSentin: true,
+		},
+		{
+			name:                       "signature is not base64",
+			signature:                  "not-base64-$$$",
+			eventCreated:               testEventCreated,
+			eventID:                    testEventID,
+			clientSecret:               testSecret,
+			wantInvalidSignatureSentin: true,
+		},
+		{
+			name:                       "wrong secret",
+			signature:                  testSignature,
+			eventCreated:               testEventCreated,
+			eventID:                    testEventID,
+			clientSecret:               "wrong_client_secret",
+			wantInvalidSignatureSentin: true,
+		},
+		{
+			name:                       "tampered eventCreated",
+			signature:                  testSignature,
+			eventCreated:               testEventCreated + 1,
+			eventID:                    testEventID,
+			clientSecret:               testSecret,
+			wantInvalidSignatureSentin: true,
+		},
+		{
+			name:                       "tampered eventID",
+			signature:                  testSignature,
+			eventCreated:               testEventCreated,
+			eventID:                    "00000000-0000-0000-0000-000000000000",
+			clientSecret:               testSecret,
+			wantInvalidSignatureSentin: true,
+		},
+		{
+			// A misconfiguration, not a bad sender: it must not masquerade as a
+			// signature mismatch, so callers can tell the two apart.
+			name:                       "empty client secret",
+			signature:                  testSignature,
+			eventCreated:               testEventCreated,
+			eventID:                    testEventID,
+			clientSecret:               "",
+			wantInvalidSignatureSentin: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Verify(tt.signature, tt.eventCreated, tt.eventID, tt.clientSecret)
+			if err == nil {
+				t.Fatal("Verify() = nil, want an error")
+			}
+			if got := errors.Is(err, ErrInvalidSignature); got != tt.wantInvalidSignatureSentin {
+				t.Errorf("errors.Is(err, ErrInvalidSignature) = %t, want %t (err = %v)", got, tt.wantInvalidSignatureSentin, err)
+			}
+		})
+	}
+}
+
+// The "." is a literal separator, not a formatting artifact: the two fields must
+// not be concatenable into the same message by different values.
+func TestVerify_SeparatorIsNotAmbiguous(t *testing.T) {
+	// "1.23" and "12.3" must sign differently.
+	a := sign(1, "23", testSecret)
+	b := sign(12, "3", testSecret)
+	if a == b {
+		t.Error("sign(1, \"23\") == sign(12, \"3\"), separator is being ignored")
+	}
+	if err := Verify(a, 12, "3", testSecret); err == nil {
+		t.Error("Verify() accepted a signature for a different (eventCreated, eventID) split")
+	}
+}
+
+func TestVerify_NegativeAndZeroEventCreated(t *testing.T) {
+	for _, created := range []int64{0, -1} {
+		if err := Verify(sign(created, testEventID, testSecret), created, testEventID, testSecret); err != nil {
+			t.Errorf("Verify() with eventCreated = %d = %v, want nil", created, err)
+		}
+	}
+}
+
+func TestSign_MatchesKnownGoodVector(t *testing.T) {
+	if got := sign(testEventCreated, testEventID, testSecret); got != testSignature {
+		t.Errorf("sign() = %q, want %q", got, testSignature)
+	}
+}


### PR DESCRIPTION
Adds `ecwid/webhooks`: typed events, signature verification, and an `http.Handler` for dispatch. Stdlib only.

## The signature does not cover the body

The headline hazard, documented loudly in the package doc and the README. Ecwid's signature is an HMAC over only `"<eventCreated>.<eventId>"` — `storeId`, `eventType`, `entityId` and `data` are all unauthenticated, and a captured webhook stays replayable forever. So the package pushes callers toward defense in depth: `Options.Deduper` for `eventID` dedupe, `Options.MaxAge` for a recency window, and doc guidance to re-fetch the entity by `EntityID` rather than trusting `Data`.

`Verify` **fails closed** on a missing/empty header and compares with `hmac.Equal`. Ecwid's own PHP example does the opposite — it reads `$signatureHeaderPresent` before assigning it, so an unsigned request skips verification entirely. That control flow is deliberately not ported, and there's a test pinning the behavior.

## `entityId` is not consistently typed

It's a JSON number for order/product events (`103878161`) but a quoted string for `application.*` (`"1003"`). A custom `UnmarshalJSON` accepts both and normalizes to `string`; both shapes are tested, plus `null`/absent and an ID past float64 precision. `MarshalJSON` reproduces the wire format so events round-trip (and so the mock in #6 emits what Ecwid really sends).

## Contents

- **`types.go`** — `Event`, all 42 `EventType` constants (grouped by required scope, incl. the `customer.personalData*` events needing `read_store_profile` rather than `read_customers`), and 8 typed `data` accessors. Accessors reject event types that don't carry that payload instead of returning a zero value.
- **`verify.go`** — `Verify`, `SignatureHeader`, `ErrInvalidSignature`.
- **`handler.go`** — `NewHandler`/`Handler`/`Options`/`Deduper`. Responds **before** invoking the callback (Ecwid allows 3s connect / 10s response), on the request goroutine after an explicit flush — so a slow callback can't trip the timeout, with no unbounded goroutines and no context canceled out from under it. Defaults to 200 and refuses to be configured with a code Ecwid treats as failure (203, 208 and all 3xx are failures — an endpoint that 301-redirects to HTTPS silently never delivers).

Docs also cover the 27-attempts-over-24h retry policy (intervals 10–26 marked unconfirmed, as Ecwid elides them), the 2-week block, and the self-trigger loop risk (REST-created orders still emit `order.created`).

## Notes for review

Two symbols beyond the issue's `Event`/`EventType`/`Verify`/`Handler` list, both for callers writing their own handler: `SignatureHeader` (else you hardcode the header name) and `ErrInvalidSignature` (to tell a bad sender → 401 from a misconfigured secret → 500). Happy to drop either.

Field-type details were confirmed against the raw docs markdown, which surfaced one asymmetry the issue didn't table: `review.*` sends `orderId` as a **number** (`63254`), while `order.*`/`invoice.*` send the human-readable **string** (`"XJ12H"`). Typed accordingly and noted in the doc comments.

## Testing

`task ecwid:lint` and `task ecwid:test` pass; suite is race-clean.

The known-good vector was computed with `openssl` rather than this package's own signing code, so it cross-checks rather than restates. The two security-critical paths were mutation-tested: making `Verify` fail open, and making `entityId` string-only, each make the suite fail.

Covers signature verify (known-good, tampered, non-base64, missing header, wrong secret, tampered `eventCreated`/`eventID`, separator ambiguity), both `entityId` shapes, no-`data` events, every typed accessor against its documented example, and the handler (valid → 200 + callback; bad signature → 401 + callback NOT fired; 405/400/413; MaxAge incl. clock skew; dedupe + fail-open; responds-before-callback; callback context not canceled; concurrency).

Unrelated: `task cli:lint` reports 3 pre-existing `govet: inline` findings in `cli/internal/cmdutil/output.go` under golangci-lint 2.12.x. CI pins 2.11.1, where that check doesn't exist, so main and this PR are unaffected. Left alone as out of scope.

Closes #64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook support with typed event definitions and payload accessors.
  * Added signature verification and an HTTP handler for processing webhook deliveries.
  * Added replay protection options, deduplication support, configurable success responses, and error callbacks.
  * Added support for numerous store, order, catalog, customer, promotion, review, invoice, and application events.

* **Documentation**
  * Added webhook setup examples, delivery behavior details, and security guidance.
  * Updated API coverage documentation to include webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->