### PR TITLE
feat(appauth): iframe payload codec for both auth modes

### DIFF
--- a/ecwid/appauth/doc.go
+++ b/ecwid/appauth/doc.go
@@ -1,0 +1,46 @@
+// Package appauth encodes and decodes the payload Ecwid injects into a native
+// app's iframe.
+//
+// # Two auth modes
+//
+// Ecwid hands an embedded app its store context in one of two mutually
+// exclusive ways. They are completely different and this package handles both.
+//
+// Default User Auth is what every native app gets unless it is switched over by
+// Ecwid. The payload is hex-encoded plaintext JSON in the URL fragment:
+//
+//	GET https://app.example.com/iframe#53035362...
+//
+// A fragment is never sent to the server, so a Go backend cannot see this
+// payload at all — it is read client-side via EcwidApp.getPayload(). Decode it
+// with [DecodeHex]; synthesize one with [EncodeHex].
+//
+// Enhanced Security User Auth is opt-in. The payload is AES-encrypted and sits
+// in the query string, so a Go server can act on it:
+//
+//	GET https://app.example.com/iframe?payload=<urlsafe-b64>&app_state=...&cache-killer=...
+//
+// Decrypt it with [Decrypt]; produce one with [Encrypt].
+//
+// # Enhanced mode availability — UNCONFIRMED
+//
+// Enhanced Security User Auth is gated behind emailing Ecwid
+// (ec.apps@lightspeedhq.com) and survives only in 2020-era documentation.
+// Whether Ecwid still grants it to new apps is unconfirmed. Do not build on the
+// AES path assuming your app has been switched to it — verify with Ecwid first.
+// The two-mode distinction itself comes from the legacy ecwid-api-docs
+// _add_to_cp.md, which the current docs dropped.
+//
+// # Default-mode payloads are unauthenticated
+//
+// A default-mode (hex) payload is plaintext with no secret involved. Anything it
+// carries is client-supplied and must not be trusted server-side. In particular,
+// re-validate the access_token against the Ecwid API before acting on it; do not
+// take the store_id or tokens in a hex payload at face value.
+//
+// # Tokens are secret
+//
+// [Payload] carries an access_token and a public_token. Its String and LogValue
+// methods redact both, so a Payload is safe to pass to fmt and log/slog. Never
+// log the raw field values.
+package appauth

--- a/ecwid/appauth/payload.go
+++ b/ecwid/appauth/payload.go
@@ -1,0 +1,196 @@
+package appauth
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// keySize is the AES-128 key length: the first 16 bytes of the client_secret,
+// raw ASCII — not hashed or KDF-derived.
+const keySize = 16
+
+// Sentinel errors from [Decrypt]. They are deliberately distinct and carry no
+// payload bytes, plaintext, or key material.
+var (
+	// ErrShortSecret means the client_secret is under 16 bytes, so there is no
+	// AES-128 key to derive.
+	ErrShortSecret = errors.New("appauth: client_secret must be at least 16 bytes")
+	// ErrShortBlob means the decoded payload is under 32 bytes, so it cannot hold
+	// a 16-byte IV plus at least one ciphertext block.
+	ErrShortBlob = errors.New("appauth: encrypted payload too short (need IV + at least one block)")
+	// ErrBlockSize means the ciphertext length is not a multiple of the AES block
+	// size.
+	ErrBlockSize = errors.New("appauth: ciphertext length is not a multiple of the AES block size")
+	// ErrPadding means the decrypted plaintext has invalid PKCS#7 padding.
+	ErrPadding = errors.New("appauth: invalid PKCS#7 padding")
+	// ErrNilPayload means a nil *Payload was passed to an encode function.
+	ErrNilPayload = errors.New("appauth: nil payload")
+)
+
+// Decrypt decodes an Enhanced Security User Auth payload: a URL-safe base64
+// blob whose first 16 bytes are the CBC IV and whose remainder is AES-128-CBC
+// ciphertext with PKCS#7 padding, keyed by the first 16 bytes of clientSecret.
+func Decrypt(payload, clientSecret string) (*Payload, error) {
+	if len(clientSecret) < keySize {
+		return nil, ErrShortSecret
+	}
+
+	decoded, err := decodeURLSafeBase64(payload)
+	if err != nil {
+		return nil, fmt.Errorf("appauth: decode payload: %w", err)
+	}
+	// Need a full IV plus at least one ciphertext block.
+	if len(decoded) < aes.BlockSize*2 {
+		return nil, ErrShortBlob
+	}
+
+	// The IV is the first block; the ciphertext is everything after it. The
+	// official C# sample passes the whole blob as ciphertext and then strips
+	// leading bytes — it only appears to work because CBC self-synchronizes and
+	// corrupts just the first block. Slice properly instead.
+	iv := decoded[:aes.BlockSize]
+	ciphertext := decoded[aes.BlockSize:]
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return nil, ErrBlockSize
+	}
+
+	block, err := aes.NewCipher([]byte(clientSecret[:keySize]))
+	if err != nil {
+		return nil, fmt.Errorf("appauth: new cipher: %w", err)
+	}
+
+	plaintext := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(plaintext, ciphertext)
+
+	plaintext, err = pkcs7Unpad(plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	var p Payload
+	if err := json.Unmarshal(plaintext, &p); err != nil {
+		return nil, fmt.Errorf("appauth: unmarshal payload JSON: %w", err)
+	}
+	return &p, nil
+}
+
+// Encrypt produces an Enhanced Security User Auth payload from p, keyed by the
+// first 16 bytes of clientSecret. It generates a random IV, so successive calls
+// on the same input yield different output. It is the inverse of [Decrypt] and
+// exists for the mock admin shell and for callers' own tests.
+func Encrypt(p *Payload, clientSecret string) (string, error) {
+	if p == nil {
+		return "", ErrNilPayload
+	}
+	if len(clientSecret) < keySize {
+		return "", ErrShortSecret
+	}
+
+	plaintext, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("appauth: marshal payload JSON: %w", err)
+	}
+
+	block, err := aes.NewCipher([]byte(clientSecret[:keySize]))
+	if err != nil {
+		return "", fmt.Errorf("appauth: new cipher: %w", err)
+	}
+
+	iv := make([]byte, aes.BlockSize)
+	if _, err := rand.Read(iv); err != nil {
+		return "", fmt.Errorf("appauth: generate IV: %w", err)
+	}
+
+	padded := pkcs7Pad(plaintext, aes.BlockSize)
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+
+	blob := make([]byte, 0, len(iv)+len(ciphertext))
+	blob = append(blob, iv...)
+	blob = append(blob, ciphertext...)
+	return encodeURLSafeBase64(blob), nil
+}
+
+// DecodeHex decodes a Default User Auth payload: hex-encoded plaintext JSON from
+// the URL fragment. The input is the fragment content without the leading '#'.
+//
+// The result is unauthenticated — no secret is involved. Re-validate its
+// access_token against the Ecwid API before trusting anything it carries.
+func DecodeHex(fragment string) (*Payload, error) {
+	raw, err := hex.DecodeString(fragment)
+	if err != nil {
+		return nil, fmt.Errorf("appauth: decode hex fragment: %w", err)
+	}
+
+	var p Payload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, fmt.Errorf("appauth: unmarshal payload JSON: %w", err)
+	}
+	return &p, nil
+}
+
+// EncodeHex produces a Default User Auth payload from p: hex-encoded plaintext
+// JSON, to be placed in the URL fragment after a '#'. It is the inverse of
+// [DecodeHex].
+func EncodeHex(p *Payload) (string, error) {
+	if p == nil {
+		return "", ErrNilPayload
+	}
+
+	raw, err := json.Marshal(p)
+	if err != nil {
+		return "", fmt.Errorf("appauth: marshal payload JSON: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+// decodeURLSafeBase64 decodes URL-safe base64 (- and _), tolerating input that
+// is missing its trailing padding.
+func decodeURLSafeBase64(s string) ([]byte, error) {
+	return base64.URLEncoding.DecodeString(padBase64(s))
+}
+
+// encodeURLSafeBase64 encodes b as URL-safe base64 (- and _) with '=' padding.
+func encodeURLSafeBase64(b []byte) string {
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+// padBase64 pads s with '=' up to a multiple of 4. Note the trap that has bitten
+// existing implementations: when len(s) is already a multiple of 4 this must add
+// nothing. The C#-style `len + (4 - len%4)` wrongly appends 4 '=' in that case.
+func padBase64(s string) string {
+	for len(s)%4 != 0 {
+		s += "="
+	}
+	return s
+}
+
+// pkcs7Pad appends PKCS#7 padding so the result is a multiple of blockSize.
+func pkcs7Pad(data []byte, blockSize int) []byte {
+	pad := blockSize - len(data)%blockSize
+	return append(data, bytes.Repeat([]byte{byte(pad)}, pad)...)
+}
+
+// pkcs7Unpad removes and validates PKCS#7 padding.
+func pkcs7Unpad(data []byte) ([]byte, error) {
+	if len(data) == 0 || len(data)%aes.BlockSize != 0 {
+		return nil, ErrPadding
+	}
+	pad := int(data[len(data)-1])
+	if pad == 0 || pad > aes.BlockSize || pad > len(data) {
+		return nil, ErrPadding
+	}
+	for _, b := range data[len(data)-pad:] {
+		if int(b) != pad {
+			return nil, ErrPadding
+		}
+	}
+	return data[:len(data)-pad], nil
+}

--- a/ecwid/appauth/payload_test.go
+++ b/ecwid/appauth/payload_test.go
@@ -133,15 +133,21 @@ func TestDecrypt_NonMultipleCiphertext(t *testing.T) {
 	}
 }
 
-// tamperLastBlock flips a byte in the final ciphertext block so PKCS#7 unpadding
-// fails, without changing the length.
+// tamperLastBlock deterministically corrupts the PKCS#7 padding without changing
+// the length. In CBC, plaintext block N depends on ciphertext block N XOR
+// ciphertext block N-1, so flipping a byte of block N-1 flips exactly the
+// corresponding byte of plaintext block N. Flipping the last byte of the
+// second-to-last ciphertext block (offset len-17) thus flips only the final
+// padding byte — always invalid. Flipping the final ciphertext block instead
+// would randomize the whole last plaintext block via the avalanche effect,
+// leaving a ~1/256 chance the result is still valid padding and the test flakes.
 func tamperLastBlock(t *testing.T, enc string) string {
 	t.Helper()
 	decoded, err := decodeURLSafeBase64(enc)
 	if err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	decoded[len(decoded)-1] ^= 0xFF
+	decoded[len(decoded)-17] ^= 0xFF
 	return encodeURLSafeBase64(decoded)
 }
 

--- a/ecwid/appauth/payload_test.go
+++ b/ecwid/appauth/payload_test.go
@@ -1,0 +1,209 @@
+package appauth
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// clientSecret used across the crypto tests. Its first 16 bytes are the AES key.
+const testClientSecret = "test_client_secret_0123456789"
+
+// fixedVector is a committed Enhanced-mode payload generated once with the
+// documented algorithm (AES-128-CBC, key = first 16 bytes of client_secret,
+// IV = "appauth-fixed-iv", PKCS#7, URL-safe base64). It is NOT the docs' hex
+// example — that string is hex, not base64, and is not a valid AES payload.
+//
+// Its plaintext begins with `{"access_token":`, so the C#-style bug that
+// corrupts the first ciphertext block would break JSON parsing and fail
+// TestDecrypt_FixedVector.
+const fixedVector = "YXBwYXV0aC1maXhlZC1pdhIzjFPUtYpLNVCK76EMJ_yHnHmCWZinMHcLWoW0fvWXh4f_Bh3q9o8Qh0IhXHvVqJkC8FpvYcoFcfcSTiHKZwPmEoo72ZNHVmTN2UoMwNmfI1oyaqW-qoXmmUcj75Eig1eQ7NFgc3cHQ5_JpzqFN9ZitEv9wWBPUy8E7_fGI0IpPXIcsMadp-azBhdITMq6mnl6rpir2wZYiDyty3Q5arXRSn9627zTiQJAaHSzr7mGpe3GwJsO-p37z_w7VXLZwA=="
+
+func samplerPayload() *Payload {
+	return &Payload{
+		StoreID:     1003,
+		Lang:        "en",
+		AccessToken: "secret_abc123def456token",
+		PublicToken: "public_zzz999yyy888token",
+		ViewMode:    "PAGE",
+		AppState:    "orderId%3A12",
+		Domain:      "app.example.test",
+	}
+}
+
+func assertEqual(t *testing.T, got, want *Payload) {
+	t.Helper()
+	if *got != *want {
+		t.Fatalf("payload mismatch:\n got = %+v\nwant = %+v", *got, *want)
+	}
+}
+
+// TestDecrypt_FixedVector cross-checks against a committed ciphertext produced
+// by the documented algorithm. It also proves correct IV handling: a
+// first-block-corrupting decode would fail here.
+func TestDecrypt_FixedVector(t *testing.T) {
+	got, err := Decrypt(fixedVector, testClientSecret)
+	if err != nil {
+		t.Fatalf("Decrypt() error = %v", err)
+	}
+	assertEqual(t, got, samplerPayload())
+}
+
+func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+	want := samplerPayload()
+
+	enc, err := Encrypt(want, testClientSecret)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+	got, err := Decrypt(enc, testClientSecret)
+	if err != nil {
+		t.Fatalf("Decrypt() error = %v", err)
+	}
+	assertEqual(t, got, want)
+}
+
+// TestEncrypt_RandomIV asserts a fresh IV per call: identical input yields
+// different ciphertext, and both still decrypt back to the original.
+func TestEncrypt_RandomIV(t *testing.T) {
+	p := samplerPayload()
+
+	a, err := Encrypt(p, testClientSecret)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+	b, err := Encrypt(p, testClientSecret)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+	if a == b {
+		t.Fatal("Encrypt produced identical output twice; IV is not random")
+	}
+	for _, enc := range []string{a, b} {
+		got, err := Decrypt(enc, testClientSecret)
+		if err != nil {
+			t.Fatalf("Decrypt() error = %v", err)
+		}
+		assertEqual(t, got, p)
+	}
+}
+
+func TestDecrypt_Errors(t *testing.T) {
+	// A valid blob to mutate for the block-size case: reuse the round-trip output.
+	valid, err := Encrypt(samplerPayload(), testClientSecret)
+	if err != nil {
+		t.Fatalf("Encrypt() error = %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		payload string
+		secret  string
+		want    error
+	}{
+		{"short secret", fixedVector, "too-short", ErrShortSecret},
+		{"short blob", encodeURLSafeBase64([]byte("only-a-few-bytes")), testClientSecret, ErrShortBlob},
+		{"bad padding", tamperLastBlock(t, valid), testClientSecret, ErrPadding},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Decrypt(tt.payload, tt.secret)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if tt.want != nil && !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+// TestDecrypt_NonMultipleCiphertext feeds a blob whose ciphertext is 8 bytes
+// short of a block boundary and asserts ErrBlockSize specifically.
+func TestDecrypt_NonMultipleCiphertext(t *testing.T) {
+	// 16-byte IV + 24 bytes: 24 is not a multiple of 16.
+	blob := make([]byte, 16+24)
+	for i := range blob {
+		blob[i] = byte(i)
+	}
+	_, err := Decrypt(encodeURLSafeBase64(blob), testClientSecret)
+	if !errors.Is(err, ErrBlockSize) {
+		t.Fatalf("error = %v, want ErrBlockSize", err)
+	}
+}
+
+// tamperLastBlock flips a byte in the final ciphertext block so PKCS#7 unpadding
+// fails, without changing the length.
+func tamperLastBlock(t *testing.T, enc string) string {
+	t.Helper()
+	decoded, err := decodeURLSafeBase64(enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	decoded[len(decoded)-1] ^= 0xFF
+	return encodeURLSafeBase64(decoded)
+}
+
+func TestEncrypt_NilAndShortSecret(t *testing.T) {
+	if _, err := Encrypt(nil, testClientSecret); !errors.Is(err, ErrNilPayload) {
+		t.Fatalf("Encrypt(nil) error = %v, want ErrNilPayload", err)
+	}
+	if _, err := Encrypt(samplerPayload(), "short"); !errors.Is(err, ErrShortSecret) {
+		t.Fatalf("Encrypt(short secret) error = %v, want ErrShortSecret", err)
+	}
+}
+
+func TestEncodeDecodeHex_RoundTrip(t *testing.T) {
+	want := samplerPayload()
+
+	enc, err := EncodeHex(want)
+	if err != nil {
+		t.Fatalf("EncodeHex() error = %v", err)
+	}
+	if strings.ContainsAny(enc, "#") {
+		t.Fatal("EncodeHex output must be bare hex without a leading '#'")
+	}
+	got, err := DecodeHex(enc)
+	if err != nil {
+		t.Fatalf("DecodeHex() error = %v", err)
+	}
+	assertEqual(t, got, want)
+}
+
+func TestDecodeHex_Errors(t *testing.T) {
+	if _, err := DecodeHex("nothex!!"); err == nil {
+		t.Fatal("expected error for invalid hex")
+	}
+	// Valid hex, but not JSON.
+	if _, err := DecodeHex("6e6f742d6a736f6e"); err == nil {
+		t.Fatal("expected error for hex that is not JSON")
+	}
+}
+
+func TestEncodeHex_Nil(t *testing.T) {
+	if _, err := EncodeHex(nil); !errors.Is(err, ErrNilPayload) {
+		t.Fatalf("EncodeHex(nil) error = %v, want ErrNilPayload", err)
+	}
+}
+
+// TestPadBase64 guards the off-by-four trap: a length already a multiple of 4
+// must gain no padding.
+func TestPadBase64(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"a", "a==="},
+		{"ab", "ab=="},
+		{"abc", "abc="},
+		{"abcd", "abcd"},         // len%4 == 0: no padding added
+		{"abcdefgh", "abcdefgh"}, // len%4 == 0: no padding added
+	}
+	for _, tt := range tests {
+		if got := padBase64(tt.in); got != tt.want {
+			t.Errorf("padBase64(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/ecwid/appauth/types.go
+++ b/ecwid/appauth/types.go
@@ -2,6 +2,7 @@ package appauth
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 )
@@ -28,6 +29,27 @@ func (p Payload) String() string {
 	)
 }
 
+// Format implements [fmt.Formatter] so every verb renders the redacted form.
+// [fmt.Stringer] only covers %v/%s/%+v: bare %#v falls back to the raw struct
+// and %d embeds field values in fmt's error text, both of which would leak the
+// tokens. Routing all verbs through here closes those holes.
+func (p Payload) Format(f fmt.State, verb rune) {
+	if verb == 'v' && f.Flag('#') {
+		io.WriteString(f, p.goString()) //nolint:errcheck // writing to fmt.State never errors usefully
+		return
+	}
+	io.WriteString(f, p.String()) //nolint:errcheck // writing to fmt.State never errors usefully
+}
+
+// goString renders the Go-syntax representation used for %#v, with tokens
+// redacted.
+func (p Payload) goString() string {
+	return fmt.Sprintf(
+		"appauth.Payload{StoreID:%d, Lang:%q, AccessToken:%q, PublicToken:%q, ViewMode:%q, AppState:%q, Domain:%q}",
+		p.StoreID, p.Lang, redact(p.AccessToken), redact(p.PublicToken), p.ViewMode, p.AppState, p.Domain,
+	)
+}
+
 // LogValue implements [slog.LogValuer] with access_token and public_token
 // redacted, so a Payload is safe to log.
 func (p Payload) LogValue() slog.Value {
@@ -42,8 +64,10 @@ func (p Payload) LogValue() slog.Value {
 	)
 }
 
-// redact masks all but the last 4 characters of a secret, matching
-// config.RedactedToken. An empty secret stays empty.
+// redact masks all but the last 4 characters of a secret, the same all-but-last-4
+// policy as config's Config.RedactedToken. Unlike that method it leaves an empty
+// secret empty rather than returning "****", so an absent optional token (e.g.
+// public_token) is not mistaken for a hidden one.
 func redact(s string) string {
 	if s == "" {
 		return ""

--- a/ecwid/appauth/types.go
+++ b/ecwid/appauth/types.go
@@ -1,0 +1,55 @@
+package appauth
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// Payload is the store context Ecwid injects into a native app's iframe. It is
+// the decoded form of both the default-mode (hex) and enhanced-mode (AES)
+// payloads.
+type Payload struct {
+	StoreID     int64  `json:"store_id"`
+	Lang        string `json:"lang"`
+	AccessToken string `json:"access_token"`
+	PublicToken string `json:"public_token"` // only with public_storefront scope
+	ViewMode    string `json:"view_mode"`    // PAGE | POPUP | INLINE (POPUP currently disabled)
+	AppState    string `json:"app_state"`    // URL-encoded; deep-linking only
+	Domain      string `json:"domain"`       // undocumented; overrides the API host
+}
+
+// String implements [fmt.Stringer] with access_token and public_token redacted,
+// so a Payload is safe to print.
+func (p Payload) String() string {
+	return fmt.Sprintf(
+		"appauth.Payload{StoreID:%d Lang:%q AccessToken:%q PublicToken:%q ViewMode:%q AppState:%q Domain:%q}",
+		p.StoreID, p.Lang, redact(p.AccessToken), redact(p.PublicToken), p.ViewMode, p.AppState, p.Domain,
+	)
+}
+
+// LogValue implements [slog.LogValuer] with access_token and public_token
+// redacted, so a Payload is safe to log.
+func (p Payload) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Int64("store_id", p.StoreID),
+		slog.String("lang", p.Lang),
+		slog.String("access_token", redact(p.AccessToken)),
+		slog.String("public_token", redact(p.PublicToken)),
+		slog.String("view_mode", p.ViewMode),
+		slog.String("app_state", p.AppState),
+		slog.String("domain", p.Domain),
+	)
+}
+
+// redact masks all but the last 4 characters of a secret, matching
+// config.RedactedToken. An empty secret stays empty.
+func redact(s string) string {
+	if s == "" {
+		return ""
+	}
+	if len(s) <= 4 {
+		return "****"
+	}
+	return strings.Repeat("*", len(s)-4) + s[len(s)-4:]
+}

--- a/ecwid/appauth/types_test.go
+++ b/ecwid/appauth/types_test.go
@@ -13,18 +13,19 @@ func TestPayload_RedactsTokens(t *testing.T) {
 	p := samplerPayload()
 	secrets := []string{p.AccessToken, p.PublicToken}
 
-	// fmt "%v" and "%s" and "%+v" all route through String().
-	for _, format := range []string{"%v", "%s", "%+v"} {
+	// Every verb routes through Format, including %#v and non-string verbs like
+	// %d that would otherwise leak the raw field values.
+	for _, format := range []string{"%v", "%s", "%+v", "%#v", "%d", "%q"} {
 		out := fmt.Sprintf(format, p)
 		for _, secret := range secrets {
 			if strings.Contains(out, secret) {
 				t.Errorf("Sprintf(%q) leaked secret %q: %s", format, secret, out)
 			}
 		}
-		// Non-secret fields should still be visible for diagnostics.
-		if !strings.Contains(out, p.Lang) {
-			t.Errorf("Sprintf(%q) dropped non-secret field lang: %s", format, out)
-		}
+	}
+	// Non-secret fields stay visible for diagnostics.
+	if out := p.String(); !strings.Contains(out, p.Lang) {
+		t.Errorf("String() dropped non-secret field lang: %s", out)
 	}
 
 	// A value (not pointer) must redact too — String has a value receiver.

--- a/ecwid/appauth/types_test.go
+++ b/ecwid/appauth/types_test.go
@@ -1,0 +1,70 @@
+package appauth
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestPayload_RedactsTokens(t *testing.T) {
+	p := samplerPayload()
+	secrets := []string{p.AccessToken, p.PublicToken}
+
+	// fmt "%v" and "%s" and "%+v" all route through String().
+	for _, format := range []string{"%v", "%s", "%+v"} {
+		out := fmt.Sprintf(format, p)
+		for _, secret := range secrets {
+			if strings.Contains(out, secret) {
+				t.Errorf("Sprintf(%q) leaked secret %q: %s", format, secret, out)
+			}
+		}
+		// Non-secret fields should still be visible for diagnostics.
+		if !strings.Contains(out, p.Lang) {
+			t.Errorf("Sprintf(%q) dropped non-secret field lang: %s", format, out)
+		}
+	}
+
+	// A value (not pointer) must redact too — String has a value receiver.
+	pv := *p
+	if out := pv.String(); strings.Contains(out, p.AccessToken) {
+		t.Errorf("value Payload leaked access_token: %s", out)
+	}
+}
+
+func TestPayload_LogValueRedacts(t *testing.T) {
+	p := samplerPayload()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.LogAttrs(context.Background(), slog.LevelInfo, "iframe", slog.Any("payload", p))
+
+	out := buf.String()
+	for _, secret := range []string{p.AccessToken, p.PublicToken} {
+		if strings.Contains(out, secret) {
+			t.Errorf("slog leaked secret %q: %s", secret, out)
+		}
+	}
+	if !strings.Contains(out, "store_id") {
+		t.Errorf("slog dropped store_id group field: %s", out)
+	}
+}
+
+func TestRedact(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"abcd", "****"},
+		{"ab", "****"},
+		{"secret_token", "********oken"},
+	}
+	for _, tt := range tests {
+		if got := redact(tt.in); got != tt.want {
+			t.Errorf("redact(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a public `ecwid/appauth` package that encodes/decodes the payload Ecwid injects into a native app's iframe, for **both** auth modes.

## What's here

- **`types.go`** — `Payload` struct (store context). `String()` + `LogValue()` redact `access_token` and `public_token`, so it's safe to `fmt`/`slog`.
- **`payload.go`**
  - Enhanced mode (AES): `Decrypt` / `Encrypt`. AES-128-CBC, key = first 16 bytes of `client_secret` (raw ASCII), IV = `decoded[:16]`, ciphertext = `decoded[16:]`, PKCS#7, URL-safe base64.
  - Default mode (hex): `DecodeHex` / `EncodeHex`. Plaintext, unauthenticated.
- **`doc.go`** — documents the two modes, the **Enhanced-mode availability caveat** (UNCONFIRMED, gated behind emailing Ecwid), and that default-mode payloads are unauthenticated.

## Traps avoided (per the spec)

- IV is sliced correctly (`decoded[16:]`), not the C#-style whole-blob-then-strip that only works because CBC self-synchronizes. The committed fixed vector's plaintext starts with `{"access_token":`, so a first-block-corrupting decode would fail the test.
- Base64 padding uses `for len(s)%4 != 0 { s += "=" }` — no off-by-four `=` when `len%4==0` (tested).
- The docs' hex "example" is **not** used as a test vector; a fresh AES vector was generated and committed.

## Tests

Round-trip (AES + hex), committed fixed vector, random-IV, error cases (short secret, short blob, non-multiple-of-16 ciphertext, bad padding), redaction in `fmt` and `slog`. `task ecwid:lint` and `task ecwid:test` pass.

Stdlib only. Minimal exported surface per `AGENTS.md`.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding and encoding Ecwid authentication payloads in both default and enhanced security formats.
  * Added encrypted payload handling with AES-based protection and validation.
  * Added structured payload fields for store context, language, tokens, view mode, application state, and domain.
  * Added automatic redaction of sensitive tokens in formatted output and logs.

* **Documentation**
  * Documented payload formats, security considerations, and safe logging practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->