### PR TITLE
feat(mock): module scaffold, cobra serve command, and server skeleton

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,6 +10,9 @@ includes:
   cli:
     taskfile: ./cli/Taskfile.yml
     dir: ./cli
+  mock:
+    taskfile: ./mock/Taskfile.yml
+    dir: ./mock
 
 tasks:
   lint:
@@ -18,6 +21,7 @@ tasks:
       - task: config:lint
       - task: ecwid:lint
       - task: cli:lint
+      - task: mock:lint
 
   lint:fix:
     desc: Run golangci-lint with auto-fix across all modules
@@ -25,6 +29,7 @@ tasks:
       - task: config:lint:fix
       - task: ecwid:lint:fix
       - task: cli:lint:fix
+      - task: mock:lint:fix
 
   test:
     desc: Run unit tests across all modules
@@ -32,6 +37,7 @@ tasks:
       - task: config:test
       - task: ecwid:test
       - task: cli:test
+      - task: mock:test
 
   tidy:
     desc: Run go mod tidy across all modules
@@ -39,6 +45,7 @@ tasks:
       - task: config:tidy
       - task: ecwid:tidy
       - task: cli:tidy
+      - task: mock:tidy
 
   e2e:
     desc: Run E2E tests against a real Ecwid store

--- a/go.work
+++ b/go.work
@@ -1,8 +1,9 @@
 go 1.26.0
 
 use (
-	./config
-	./ecwid
 	./cli
+	./config
 	./e2e
+	./ecwid
+	./mock
 )

--- a/mock/AGENTS.md
+++ b/mock/AGENTS.md
@@ -1,0 +1,113 @@
+# mock/ — Ecwid local mock server
+
+## Overview
+
+`ecwid-mock` is an **app developer's** tool: a local stand-in for an Ecwid store
+so a Go developer can exercise an embedded app without a real store. Ecwid
+renders apps in an iframe inside the store admin and injects context via a JS
+SDK; it provides **no** local tooling and **no** webhook test tooling (no test
+sender, no replay, no delivery log). This module fills that gap.
+
+It is a standalone Go module wired into `go.work`, alongside `config/`,
+`ecwid/`, `cli/`, and `e2e/`.
+
+## ⚠️ Route namespace convention — the contract other issues build on
+
+The HTTP surface is partitioned into three namespaces. **Do not cross these
+lines.** Later issues (#4 shell, #5 storage, #6 trigger, #7 proxy) plug into
+exactly one namespace each.
+
+| Prefix | Purpose | Owner issue |
+|--------|---------|-------------|
+| `/` | Admin shell — the developer-facing UI that hosts the app iframe | #4 |
+| `/api/v3/{storeId}/...` | Simulated Ecwid REST; proxy or `501` fallback for unimplemented routes | #5, #7 |
+| `/_mock/...` | The mock's own control API (health, webhook trigger, …) | #6 |
+
+The `/_mock/` prefix is reserved so the mock's control plane can **never collide
+with a real Ecwid REST route** (real routes live under `/api/v3/`). Register
+control-plane endpoints only under `/_mock/`.
+
+Routing uses `net/http.ServeMux` with Go 1.22+ method+pattern syntax
+(`"GET /_mock/health"`, `"POST /_mock/webhooks/trigger"`). Add routes in
+`internal/server/routes` (`server.routes()`), keeping one handler file per
+concern.
+
+## Structure
+
+```
+mock/
+├── main.go                     # entry point, slog setup, version injection
+├── cmd/
+│   ├── root.go                 # cobra root (ecwid-mock), --version
+│   └── serve.go                # `ecwid-mock serve` + flags, config load, banner
+└── internal/
+    ├── config/                 # mock Config: flags > env > defaults, validation
+    │   └── config.go
+    └── server/                 # ServeMux, request logging, graceful lifecycle
+        ├── server.go           # New, routes, Run (graceful shutdown)
+        ├── middleware.go       # structured slog request logging
+        └── health.go           # GET /_mock/health
+```
+
+Everything lives under `internal/` — this module ships a binary, not a library,
+so it has **zero exported API surface** to keep as a compatibility contract.
+
+## Configuration
+
+The mock's config is **local to this module** and deliberately distinct from
+`config.Config` (which carries `StoreID`/`Token` for real API calls). Do **not**
+widen `config.Config` with these developer-tool fields — that module is a
+published compatibility contract.
+
+Precedence is **flags > env > defaults**, matching `config/`'s behavior.
+
+| Flag | Env | Default | Purpose |
+|------|-----|---------|---------|
+| `--app-url` | `ECWID_MOCK_APP_URL` | *(required)* | URL of the app to iframe |
+| `--client-id` | `ECWID_MOCK_CLIENT_ID` | `mock-app` | App `client_id`; also `EcwidApp.init({app_id})` |
+| `--client-secret` | `ECWID_MOCK_CLIENT_SECRET` | *(generated)* | Signs webhooks + encrypts payloads; **≥16 bytes** |
+| `--store-id` | `ECWID_MOCK_STORE_ID` | `1003` | Store ID in the payload |
+| `--auth-mode` | `ECWID_MOCK_AUTH_MODE` | `default` | `default` (hex fragment) \| `enhanced` (AES query) |
+| `--webhook-url` | `ECWID_MOCK_WEBHOOK_URL` | *(optional)* | Where triggered webhooks POST |
+| `--port` | `ECWID_MOCK_PORT` | `8080` | Listen port |
+| `--proxy-store` / `--proxy-token` | `ECWID_MOCK_PROXY_*` | *(optional)* | Forward unimplemented REST to a real store |
+
+`--client-secret` **must be ≥16 bytes** — `appauth.Encrypt` derives an AES-128
+key from `client_secret[:16]`. It is validated at startup (referencing
+`appauth.ErrShortSecret`), never at request time. When no secret is supplied one
+is generated (≥16 bytes) and **printed in the startup banner** so the developer
+can configure their app to match; a **user-supplied** secret is never printed.
+
+## Dependencies
+
+`config` + `ecwid` (local `replace` during dev, matching `ecwid/go.mod`) +
+**cobra**. Cobra is the repo's one blessed external dep. **No other external
+deps** — `net/http`, `crypto/rand`, `log/slog`, stdlib only.
+
+## Security
+
+- **NEVER** log `--client-secret`, `access_token`, or any credential at any
+  level. Request logging records only method, path, status, bytes, duration, and
+  remote address — no bodies, headers, or query strings.
+- Redact secrets for diagnostics with `config.RedactedClientSecret()` /
+  `RedactedProxyToken()`, which reuse `config.RedactedToken()`.
+
+## Commands
+
+```bash
+task mock:lint     # golangci-lint
+task mock:test     # go test ./... -race
+task mock:tidy     # go mod tidy
+
+# Run it:
+go run ./mock serve --app-url=http://localhost:3000
+curl localhost:8080/_mock/health   # -> 200 {"status":"ok"}
+```
+
+## Rules
+
+- All commands use `RunE` (return errors, don't `os.Exit`).
+- `http.Server` sets `ReadHeaderTimeout` (gosec/golangci require it).
+- Graceful shutdown on SIGINT/SIGTERM via `signal.NotifyContext`.
+- Version is injected at build time via `-ldflags "-X main.version=..."`.
+- Conventional commits, signed. See root `AGENTS.md`.

--- a/mock/AGENTS.md
+++ b/mock/AGENTS.md
@@ -28,9 +28,9 @@ with a real Ecwid REST route** (real routes live under `/api/v3/`). Register
 control-plane endpoints only under `/_mock/`.
 
 Routing uses `net/http.ServeMux` with Go 1.22+ method+pattern syntax
-(`"GET /_mock/health"`, `"POST /_mock/webhooks/trigger"`). Add routes in
-`internal/server/routes` (`server.routes()`), keeping one handler file per
-concern.
+(`"GET /_mock/health"`, `"POST /_mock/webhooks/trigger"`). Register routes in
+`server.routes()` (`internal/server/server.go`), keeping one handler file per
+concern under `internal/server/`.
 
 ## Structure
 

--- a/mock/Taskfile.yml
+++ b/mock/Taskfile.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+tasks:
+  lint:
+    desc: Run golangci-lint on mock module
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - golangci-lint run ./...
+
+  lint:fix:
+    desc: Run golangci-lint with auto-fix on mock module
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - golangci-lint run --fix ./...
+
+  test:
+    desc: Run tests for mock module
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - go test ./... -race -count=1
+
+  tidy:
+    desc: Run go mod tidy for mock module
+    dir: '{{.TASKFILE_DIR}}'
+    cmds:
+      - go mod tidy

--- a/mock/cmd/root.go
+++ b/mock/cmd/root.go
@@ -1,0 +1,27 @@
+// Package cmd wires the ecwid-mock cobra command tree.
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var appVersion = "dev"
+
+// SetVersion sets the application version, injected at build time and reported
+// by --version. Called from main.
+func SetVersion(v string) {
+	appVersion = v
+	rootCmd.Version = v
+}
+
+var rootCmd = &cobra.Command{
+	Use:     "ecwid-mock",
+	Short:   "Local mock of an Ecwid store for embedded-app development",
+	Long:    "ecwid-mock runs a local stand-in for an Ecwid store: it serves the app in an\niframe, simulates the REST API, and lets you trigger webhooks — none of which\nEcwid provides tooling for.",
+	Version: appVersion,
+}
+
+// Execute runs the root command.
+func Execute() error {
+	return rootCmd.Execute()
+}

--- a/mock/cmd/serve.go
+++ b/mock/cmd/serve.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+	"github.com/matthiasbruns/ecwid-go/mock/internal/server"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve",
+	Short: "Start the mock server",
+	Long:  "Start the mock HTTP server: the admin shell, the simulated Ecwid REST API,\nand the mock's control API.",
+	RunE:  runServe,
+	// A config/validation error from RunE is not a usage error, so don't bury
+	// the message under a flags dump. Cobra still prints flag-parse errors.
+	SilenceUsage: true,
+}
+
+func init() {
+	f := serveCmd.Flags()
+	f.String("app-url", "", "URL of the app to iframe, e.g. http://localhost:3000 (env: ECWID_MOCK_APP_URL) (required)")
+	f.String("client-id", config.DefaultClientID, "app client_id; also EcwidApp.init({app_id}) (env: ECWID_MOCK_CLIENT_ID)")
+	f.String("client-secret", "", "signs webhooks and encrypts payloads; must be >=16 bytes; generated if unset (env: ECWID_MOCK_CLIENT_SECRET)")
+	f.String("store-id", config.DefaultStoreID, "store ID placed in the auth payload (env: ECWID_MOCK_STORE_ID)")
+	f.String("auth-mode", config.DefaultAuthMode, "iframe auth mode: default (hex fragment) | enhanced (AES query) (env: ECWID_MOCK_AUTH_MODE)")
+	f.String("webhook-url", "", "where triggered webhooks POST (env: ECWID_MOCK_WEBHOOK_URL)")
+	f.Int("port", config.DefaultPort, "listen port (env: ECWID_MOCK_PORT)")
+	f.String("proxy-store", "", "store ID to forward unimplemented REST calls to (env: ECWID_MOCK_PROXY_STORE)")
+	f.String("proxy-token", "", "access token for the proxy store (env: ECWID_MOCK_PROXY_TOKEN)")
+
+	rootCmd.AddCommand(serveCmd)
+}
+
+func runServe(cmd *cobra.Command, _ []string) error {
+	cfg, err := config.Load(cmd)
+	if err != nil {
+		return err
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	if err := printBanner(cmd.OutOrStdout(), &cfg); err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	srv := server.New(cfg, slog.Default())
+	return srv.Run(ctx)
+}
+
+// printBanner writes the human-facing startup summary. It prints the generated
+// client_secret only when the mock generated it, so the developer can configure
+// their app to match — a user-supplied secret is never printed.
+func printBanner(w io.Writer, cfg *config.Config) error {
+	banner := "ecwid-mock\n" +
+		fmt.Sprintf("  admin:      http://localhost:%d/\n", cfg.Port) +
+		fmt.Sprintf("  app URL:    %s\n", cfg.AppURL) +
+		fmt.Sprintf("  store ID:   %s\n", cfg.StoreID) +
+		fmt.Sprintf("  auth mode:  %s\n", cfg.AuthMode) +
+		fmt.Sprintf("  client_id:  %s\n", cfg.ClientID)
+	if cfg.SecretGenerated {
+		banner += fmt.Sprintf("  client_secret (generated): %s\n", cfg.ClientSecret) +
+			"  ^ configure your app with this secret; override with --client-secret\n"
+	}
+	_, err := io.WriteString(w, banner)
+	return err
+}

--- a/mock/go.mod
+++ b/mock/go.mod
@@ -1,0 +1,19 @@
+module github.com/matthiasbruns/ecwid-go/mock
+
+go 1.26.0
+
+require (
+	github.com/matthiasbruns/ecwid-go/config v0.0.0
+	github.com/matthiasbruns/ecwid-go/ecwid v0.0.0
+	github.com/spf13/cobra v1.9.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+)
+
+replace (
+	github.com/matthiasbruns/ecwid-go/config => ../config
+	github.com/matthiasbruns/ecwid-go/ecwid => ../ecwid
+)

--- a/mock/go.sum
+++ b/mock/go.sum
@@ -1,0 +1,11 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mock/internal/config/config.go
+++ b/mock/internal/config/config.go
@@ -1,0 +1,232 @@
+// Package config holds the mock server's configuration.
+//
+// The mock is an *app developer's* tool: it stands in for a real Ecwid store so
+// a Go developer can exercise their embedded app locally. Its configuration is
+// therefore deliberately different in shape from the top-level config.Config
+// (which carries StoreID/Token for real API calls). Those two must not be
+// merged — config.Config is a published compatibility contract and these
+// developer-tool fields do not belong to API clients.
+package config
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	appconfig "github.com/matthiasbruns/ecwid-go/config"
+	"github.com/matthiasbruns/ecwid-go/ecwid/appauth"
+)
+
+const (
+	// DefaultClientID is the default app client_id, also used as
+	// EcwidApp.init({app_id}).
+	DefaultClientID = "mock-app"
+
+	// DefaultStoreID is the default store ID placed in the auth payload.
+	DefaultStoreID = "1003"
+
+	// DefaultAuthMode is the default iframe auth mode.
+	DefaultAuthMode = AuthModeDefault
+
+	// DefaultPort is the default listen port.
+	DefaultPort = 8080
+
+	// AuthModeDefault is Default User Auth: a hex-encoded plaintext payload in
+	// the URL fragment (see ecwid/appauth).
+	AuthModeDefault = "default"
+
+	// AuthModeEnhanced is Enhanced Security User Auth: an AES-encrypted payload
+	// in the query string (see ecwid/appauth).
+	AuthModeEnhanced = "enhanced"
+
+	// MinClientSecretLen is the minimum client_secret length in bytes. appauth
+	// derives an AES-128 key from the first 16 bytes of the secret, so anything
+	// shorter cannot sign webhooks or encrypt payloads.
+	MinClientSecretLen = 16
+
+	// generatedSecretBytes is the number of random bytes used when generating a
+	// client_secret. Hex-encoding doubles the length, comfortably clearing
+	// MinClientSecretLen.
+	generatedSecretBytes = 16
+)
+
+// Config is the mock server's runtime configuration.
+type Config struct {
+	// AppURL is the URL of the app to iframe (e.g. http://localhost:3000).
+	// Required.
+	AppURL string
+
+	// ClientID is the app client_id, also used as EcwidApp.init({app_id}).
+	ClientID string
+
+	// ClientSecret signs webhooks and encrypts payloads. Must be at least
+	// MinClientSecretLen bytes. Generated if not provided.
+	ClientSecret string
+
+	// StoreID is the store ID placed in the auth payload.
+	StoreID string
+
+	// AuthMode selects the iframe auth mode: AuthModeDefault or AuthModeEnhanced.
+	AuthMode string
+
+	// WebhookURL is where triggered webhooks POST. Optional.
+	WebhookURL string
+
+	// Port is the listen port.
+	Port int
+
+	// ProxyStore is the store ID to forward unimplemented REST calls to.
+	// Optional.
+	ProxyStore string
+
+	// ProxyToken is the access token for the proxy store. Optional.
+	ProxyToken string
+
+	// SecretGenerated reports whether ClientSecret was generated rather than
+	// supplied. When true, the startup banner prints it so the developer can
+	// configure their app to match.
+	SecretGenerated bool
+}
+
+// RedactedClientSecret returns the client_secret with all but the last 4
+// characters masked. Never log the raw secret; use this for diagnostics.
+func (c *Config) RedactedClientSecret() string {
+	return redact(c.ClientSecret)
+}
+
+// RedactedProxyToken returns the proxy token with all but the last 4 characters
+// masked, or "" when no proxy token is configured.
+func (c *Config) RedactedProxyToken() string {
+	if c.ProxyToken == "" {
+		return ""
+	}
+	return redact(c.ProxyToken)
+}
+
+// redact masks a secret for logging, reusing config.RedactedToken so the mock
+// and the API client mask credentials identically.
+func redact(secret string) string {
+	rc := appconfig.Config{Token: secret}
+	return rc.RedactedToken()
+}
+
+// Validate checks required fields and value constraints.
+func (c *Config) Validate() error {
+	var errs []string
+
+	if c.AppURL == "" {
+		errs = append(errs, "--app-url is required (env: ECWID_MOCK_APP_URL)")
+	} else if u, err := url.Parse(c.AppURL); err != nil || u.Scheme == "" || u.Host == "" {
+		errs = append(errs, fmt.Sprintf("--app-url %q is not a valid absolute URL", c.AppURL))
+	}
+
+	if len(c.ClientSecret) < MinClientSecretLen {
+		errs = append(errs, fmt.Sprintf(
+			"--client-secret must be at least %d bytes for AES-128 (%v), got %d",
+			MinClientSecretLen, appauth.ErrShortSecret, len(c.ClientSecret)))
+	}
+
+	if c.AuthMode != AuthModeDefault && c.AuthMode != AuthModeEnhanced {
+		errs = append(errs, fmt.Sprintf(
+			"--auth-mode %q is invalid (must be %q or %q)", c.AuthMode, AuthModeDefault, AuthModeEnhanced))
+	}
+
+	if c.Port < 1 || c.Port > 65535 {
+		errs = append(errs, fmt.Sprintf("--port %d is out of range (1-65535)", c.Port))
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("config validation: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// Load resolves configuration with precedence flags > env > defaults, matching
+// the config module's behavior. cmd supplies the parsed flags; a flag counts
+// only when explicitly set (Changed), so an unset flag falls through to env
+// then default. When no client_secret is supplied one is generated and
+// SecretGenerated is set.
+func Load(cmd *cobra.Command) (Config, error) {
+	cfg := Config{
+		ClientID: DefaultClientID,
+		StoreID:  DefaultStoreID,
+		AuthMode: DefaultAuthMode,
+		Port:     DefaultPort,
+	}
+
+	cfg.AppURL = resolveString(cmd, "app-url", "ECWID_MOCK_APP_URL", "")
+	cfg.ClientID = resolveString(cmd, "client-id", "ECWID_MOCK_CLIENT_ID", DefaultClientID)
+	cfg.ClientSecret = resolveString(cmd, "client-secret", "ECWID_MOCK_CLIENT_SECRET", "")
+	cfg.StoreID = resolveString(cmd, "store-id", "ECWID_MOCK_STORE_ID", DefaultStoreID)
+	cfg.AuthMode = resolveString(cmd, "auth-mode", "ECWID_MOCK_AUTH_MODE", DefaultAuthMode)
+	cfg.WebhookURL = resolveString(cmd, "webhook-url", "ECWID_MOCK_WEBHOOK_URL", "")
+	cfg.ProxyStore = resolveString(cmd, "proxy-store", "ECWID_MOCK_PROXY_STORE", "")
+	cfg.ProxyToken = resolveString(cmd, "proxy-token", "ECWID_MOCK_PROXY_TOKEN", "")
+
+	port, err := resolvePort(cmd)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Port = port
+
+	if cfg.ClientSecret == "" {
+		secret, err := generateSecret()
+		if err != nil {
+			return Config{}, fmt.Errorf("generate client_secret: %w", err)
+		}
+		cfg.ClientSecret = secret
+		cfg.SecretGenerated = true
+	}
+
+	return cfg, nil
+}
+
+// resolveString applies flags > env > default for a string value.
+func resolveString(cmd *cobra.Command, flag, env, def string) string {
+	if cmd != nil {
+		if f := cmd.Flags().Lookup(flag); f != nil && f.Changed {
+			return f.Value.String()
+		}
+	}
+	if v, ok := os.LookupEnv(env); ok {
+		return v
+	}
+	return def
+}
+
+// resolvePort applies flags > env > default for the listen port.
+func resolvePort(cmd *cobra.Command) (int, error) {
+	if cmd != nil {
+		if f := cmd.Flags().Lookup("port"); f != nil && f.Changed {
+			p, err := cmd.Flags().GetInt("port")
+			if err != nil {
+				return 0, fmt.Errorf("parse --port: %w", err)
+			}
+			return p, nil
+		}
+	}
+	if v, ok := os.LookupEnv("ECWID_MOCK_PORT"); ok {
+		p, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("parse ECWID_MOCK_PORT %q: %w", v, err)
+		}
+		return p, nil
+	}
+	return DefaultPort, nil
+}
+
+// generateSecret returns a hex-encoded random client_secret of at least
+// MinClientSecretLen bytes.
+func generateSecret() (string, error) {
+	buf := make([]byte, generatedSecretBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/mock/internal/config/config_test.go
+++ b/mock/internal/config/config_test.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newCmd builds a command with the same flags serve registers, so Load can be
+// exercised in isolation.
+func newCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "serve"}
+	f := cmd.Flags()
+	f.String("app-url", "", "")
+	f.String("client-id", DefaultClientID, "")
+	f.String("client-secret", "", "")
+	f.String("store-id", DefaultStoreID, "")
+	f.String("auth-mode", DefaultAuthMode, "")
+	f.String("webhook-url", "", "")
+	f.Int("port", DefaultPort, "")
+	f.String("proxy-store", "", "")
+	f.String("proxy-token", "", "")
+	return cmd
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	cmd := newCmd()
+	if err := cmd.Flags().Set("app-url", "http://localhost:3000"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cmd)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.ClientID != DefaultClientID {
+		t.Errorf("ClientID = %q, want %q", cfg.ClientID, DefaultClientID)
+	}
+	if cfg.StoreID != DefaultStoreID {
+		t.Errorf("StoreID = %q, want %q", cfg.StoreID, DefaultStoreID)
+	}
+	if cfg.AuthMode != DefaultAuthMode {
+		t.Errorf("AuthMode = %q, want %q", cfg.AuthMode, DefaultAuthMode)
+	}
+	if cfg.Port != DefaultPort {
+		t.Errorf("Port = %d, want %d", cfg.Port, DefaultPort)
+	}
+	if !cfg.SecretGenerated {
+		t.Error("SecretGenerated = false, want true when no secret supplied")
+	}
+	if len(cfg.ClientSecret) < MinClientSecretLen {
+		t.Errorf("generated ClientSecret len = %d, want >= %d", len(cfg.ClientSecret), MinClientSecretLen)
+	}
+}
+
+func TestLoad_FlagsOverrideEnv(t *testing.T) {
+	t.Setenv("ECWID_MOCK_STORE_ID", "env-store")
+	t.Setenv("ECWID_MOCK_PORT", "9999")
+
+	cmd := newCmd()
+	for k, v := range map[string]string{
+		"app-url":  "http://localhost:3000",
+		"store-id": "flag-store",
+		"port":     "1234",
+	} {
+		if err := cmd.Flags().Set(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg, err := Load(cmd)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.StoreID != "flag-store" {
+		t.Errorf("StoreID = %q, want flag to win over env", cfg.StoreID)
+	}
+	if cfg.Port != 1234 {
+		t.Errorf("Port = %d, want flag 1234 to win over env", cfg.Port)
+	}
+}
+
+func TestLoad_EnvOverridesDefault(t *testing.T) {
+	t.Setenv("ECWID_MOCK_APP_URL", "http://env-app:3000")
+	t.Setenv("ECWID_MOCK_STORE_ID", "env-store")
+	t.Setenv("ECWID_MOCK_PORT", "9999")
+
+	cfg, err := Load(newCmd())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.AppURL != "http://env-app:3000" {
+		t.Errorf("AppURL = %q, want env value", cfg.AppURL)
+	}
+	if cfg.StoreID != "env-store" {
+		t.Errorf("StoreID = %q, want env value", cfg.StoreID)
+	}
+	if cfg.Port != 9999 {
+		t.Errorf("Port = %d, want env 9999", cfg.Port)
+	}
+}
+
+func TestLoad_SuppliedSecretNotGenerated(t *testing.T) {
+	cmd := newCmd()
+	if err := cmd.Flags().Set("app-url", "http://localhost:3000"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("client-secret", "0123456789abcdef0123"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cmd)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.SecretGenerated {
+		t.Error("SecretGenerated = true, want false when secret supplied")
+	}
+	if cfg.ClientSecret != "0123456789abcdef0123" {
+		t.Errorf("ClientSecret = %q, want supplied value", cfg.ClientSecret)
+	}
+}
+
+func TestLoad_InvalidEnvPort(t *testing.T) {
+	t.Setenv("ECWID_MOCK_PORT", "not-a-number")
+
+	if _, err := Load(newCmd()); err == nil {
+		t.Fatal("Load: want error for non-numeric ECWID_MOCK_PORT, got nil")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	validSecret := "0123456789abcdef" // exactly 16 bytes
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "valid",
+			cfg:  Config{AppURL: "http://localhost:3000", ClientSecret: validSecret, AuthMode: AuthModeDefault, Port: 8080},
+		},
+		{
+			name:    "missing app-url",
+			cfg:     Config{ClientSecret: validSecret, AuthMode: AuthModeDefault, Port: 8080},
+			wantErr: "--app-url is required",
+		},
+		{
+			name:    "invalid app-url",
+			cfg:     Config{AppURL: "not-a-url", ClientSecret: validSecret, AuthMode: AuthModeDefault, Port: 8080},
+			wantErr: "not a valid absolute URL",
+		},
+		{
+			name:    "short secret",
+			cfg:     Config{AppURL: "http://localhost:3000", ClientSecret: "tooshort", AuthMode: AuthModeDefault, Port: 8080},
+			wantErr: "at least 16 bytes",
+		},
+		{
+			name:    "invalid auth mode",
+			cfg:     Config{AppURL: "http://localhost:3000", ClientSecret: validSecret, AuthMode: "bogus", Port: 8080},
+			wantErr: "--auth-mode",
+		},
+		{
+			name:    "port out of range",
+			cfg:     Config{AppURL: "http://localhost:3000", ClientSecret: validSecret, AuthMode: AuthModeDefault, Port: 70000},
+			wantErr: "out of range",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Validate() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRedactedSecrets(t *testing.T) {
+	cfg := Config{ClientSecret: "super_secret_value", ProxyToken: "proxy_token_value"}
+
+	if got := cfg.RedactedClientSecret(); strings.Contains(got, "super_secret") {
+		t.Errorf("RedactedClientSecret leaked secret: %q", got)
+	}
+	if got := cfg.RedactedProxyToken(); strings.Contains(got, "proxy_token") {
+		t.Errorf("RedactedProxyToken leaked token: %q", got)
+	}
+
+	empty := Config{}
+	if got := empty.RedactedProxyToken(); got != "" {
+		t.Errorf("RedactedProxyToken() = %q, want empty when no token set", got)
+	}
+}

--- a/mock/internal/server/health.go
+++ b/mock/internal/server/health.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleHealth serves GET /_mock/health with 200 {"status":"ok"} for CI
+// readiness polling.
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	// Encoding a fixed map cannot fail; ignore the error to keep the handler
+	// simple, and there is nothing actionable to do if the client has gone away.
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/mock/internal/server/middleware.go
+++ b/mock/internal/server/middleware.go
@@ -1,0 +1,50 @@
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// statusRecorder captures the response status code and byte count for logging.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+	bytes  int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += n
+	return n, err
+}
+
+// logRequests logs one structured line per request: method, path, status,
+// byte count, duration, and remote address. It deliberately logs no request
+// bodies, headers, query strings, or credentials so that secrets and access
+// tokens can never leak into logs.
+func logRequests(log *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		next.ServeHTTP(rec, r)
+
+		log.Info("request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rec.status,
+			"bytes", rec.bytes,
+			"duration_ms", time.Since(start).Milliseconds(),
+			"remote", r.RemoteAddr,
+		)
+	})
+}

--- a/mock/internal/server/middleware.go
+++ b/mock/internal/server/middleware.go
@@ -9,19 +9,25 @@ import (
 // statusRecorder captures the response status code and byte count for logging.
 type statusRecorder struct {
 	http.ResponseWriter
-	status int
-	bytes  int
+	status      int
+	bytes       int
+	wroteHeader bool
 }
 
 func (r *statusRecorder) WriteHeader(code int) {
-	r.status = code
+	// Only the first WriteHeader reaches the client, so record only the first to
+	// keep the logged status consistent with what was actually sent.
+	if !r.wroteHeader {
+		r.status = code
+		r.wroteHeader = true
+	}
 	r.ResponseWriter.WriteHeader(code)
 }
 
 func (r *statusRecorder) Write(b []byte) (int, error) {
-	if r.status == 0 {
-		r.status = http.StatusOK
-	}
+	// An implicit WriteHeader(200) fires on first Write; mark it so a later
+	// explicit WriteHeader cannot retroactively change the recorded status.
+	r.wroteHeader = true
 	n, err := r.ResponseWriter.Write(b)
 	r.bytes += n
 	return n, err

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -32,6 +32,13 @@ import (
 // mitigating slow-header (Slowloris) clients. Required by gosec/golangci.
 const readHeaderTimeout = 10 * time.Second
 
+// readTimeout bounds how long the server waits for a full request (headers plus
+// body), so a slow client cannot hold a connection open indefinitely.
+const readTimeout = 30 * time.Second
+
+// idleTimeout bounds how long an idle keep-alive connection is retained.
+const idleTimeout = 120 * time.Second
+
 // shutdownTimeout bounds graceful shutdown before in-flight requests are
 // abandoned.
 const shutdownTimeout = 10 * time.Second
@@ -66,6 +73,11 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 		Addr:              addr,
 		Handler:           logRequests(log, mux),
 		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		IdleTimeout:       idleTimeout,
+		// WriteTimeout is intentionally left unset: later issues add streaming /
+		// long-poll control endpoints (e.g. the admin shell's live webhook
+		// delivery log) that a fixed write deadline would sever mid-response.
 	}
 
 	return s

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -1,0 +1,118 @@
+// Package server assembles the mock HTTP server: its route namespaces, request
+// logging, and graceful lifecycle.
+//
+// # Route namespaces
+//
+// The mux is partitioned into three namespaces that later issues build on:
+//
+//	/                        -> admin shell (the developer-facing UI)
+//	/api/v3/{storeId}/...    -> simulated Ecwid REST (proxy/501 fallback)
+//	/_mock/...               -> the mock's own control API
+//
+// The /_mock/ prefix is reserved for the mock's control plane so it can never
+// collide with a real Ecwid REST route. This skeleton registers only
+// GET /_mock/health; the other namespaces are established here and filled in by
+// later issues.
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+// readHeaderTimeout bounds how long the server waits for request headers,
+// mitigating slow-header (Slowloris) clients. Required by gosec/golangci.
+const readHeaderTimeout = 10 * time.Second
+
+// shutdownTimeout bounds graceful shutdown before in-flight requests are
+// abandoned.
+const shutdownTimeout = 10 * time.Second
+
+// Server wraps the HTTP server and its configuration.
+type Server struct {
+	cfg  config.Config
+	log  *slog.Logger
+	mux  *http.ServeMux
+	http *http.Server
+}
+
+// New builds a Server with all routes registered. The provided logger is used
+// for request and lifecycle logging.
+func New(cfg config.Config, log *slog.Logger) *Server {
+	if log == nil {
+		log = slog.Default()
+	}
+
+	mux := http.NewServeMux()
+	addr := net.JoinHostPort("", strconv.Itoa(cfg.Port))
+
+	s := &Server{
+		cfg: cfg,
+		log: log,
+		mux: mux,
+	}
+
+	s.routes()
+
+	s.http = &http.Server{
+		Addr:              addr,
+		Handler:           logRequests(log, mux),
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+
+	return s
+}
+
+// routes registers the mock's HTTP handlers. Only the control-plane health
+// check exists in this skeleton; the admin shell, simulated REST, and remaining
+// control endpoints are added by later issues.
+func (s *Server) routes() {
+	s.mux.HandleFunc("GET /_mock/health", handleHealth)
+}
+
+// Run starts the server and blocks until ctx is canceled (e.g. on SIGINT or
+// SIGTERM), then shuts down gracefully. It returns nil on a clean shutdown.
+func (s *Server) Run(ctx context.Context) error {
+	errCh := make(chan error, 1)
+
+	go func() {
+		s.log.Info("mock server listening",
+			"addr", s.http.Addr,
+			"store_id", s.cfg.StoreID,
+			"auth_mode", s.cfg.AuthMode,
+			"client_id", s.cfg.ClientID,
+		)
+		if err := s.http.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		s.log.Info("shutdown signal received, draining connections")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := s.http.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("graceful shutdown: %w", err)
+		}
+		s.log.Info("mock server stopped")
+		return nil
+	}
+}
+
+// Handler exposes the underlying mux for tests.
+func (s *Server) Handler() http.Handler {
+	return s.mux
+}

--- a/mock/internal/server/server_test.go
+++ b/mock/internal/server/server_test.go
@@ -55,8 +55,14 @@ func TestRun_GracefulShutdown(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- srv.Run(ctx) }()
 
-	// Give the listener a moment to come up, then signal shutdown.
-	time.Sleep(50 * time.Millisecond)
+	// Give the listener a moment to come up. If Run returns during this window it
+	// failed to start — fail fast rather than masking it until the later timeout.
+	select {
+	case err := <-done:
+		t.Fatalf("Run returned before shutdown was requested: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
 	cancel()
 
 	select {

--- a/mock/internal/server/server_test.go
+++ b/mock/internal/server/server_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+func TestHealth(t *testing.T) {
+	srv := New(config.Config{Port: 0}, discardLogger())
+
+	req := httptest.NewRequest(http.MethodGet, "/_mock/health", http.NoBody)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("status = %q, want ok", body["status"])
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestHealth_WrongMethod(t *testing.T) {
+	srv := New(config.Config{Port: 0}, discardLogger())
+
+	req := httptest.NewRequest(http.MethodPost, "/_mock/health", http.NoBody)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d for POST to GET-only route", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestRun_GracefulShutdown(t *testing.T) {
+	srv := New(config.Config{Port: 0}, discardLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	// Give the listener a moment to come up, then signal shutdown.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned %v, want nil on graceful shutdown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/mock/main.go
+++ b/mock/main.go
@@ -1,0 +1,26 @@
+// Command ecwid-mock runs a local stand-in for an Ecwid store so a Go developer
+// can exercise an embedded app without a real store.
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/matthiasbruns/ecwid-go/mock/cmd"
+)
+
+// version is set at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	cmd.SetVersion(version)
+
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Creates the standalone `mock/` module — the foundation for the **Dev/Mock Environment** milestone. It boots, routes, logs, and exits cleanly; the admin shell (#67), storage (#68), webhook trigger (#69), proxy (#70), and release wiring (#72) build on the mux and config established here.

## What's in scope

- **Module setup** — `mock/go.mod` (`go 1.26.0`, deps: `config` + `ecwid` local `replace` + cobra, nothing else), `./mock` added to `go.work`, `mock/Taskfile.yml` (`lint`/`lint:fix`/`test`/`tidy`) wired into the root Taskfile includes and the `lint`/`test`/`tidy` aggregates.
- **`mock/AGENTS.md`** — documents module conventions and, prominently, the **route namespace contract** the sibling issues build against.
- **Config** (`internal/config`) — mock-local config with precedence **flags > env > defaults** (stdlib + cobra, no viper). Kept separate from `config.Config` (a published contract). `--client-secret` is validated **≥16 bytes** at startup (references `appauth.ErrShortSecret`); when unset a ≥16-byte secret is generated and printed in the banner so the developer can match their app.
- **Server** (`internal/server`) — `http.ServeMux` with Go 1.22+ method+pattern routing, `http.Server` with `ReadHeaderTimeout`, graceful shutdown on SIGINT/SIGTERM, and structured `slog` request logging (method/path/status/bytes/duration/remote only — never bodies, headers, query strings, or credentials).
- **Health** — `GET /_mock/health` → `200 {"status":"ok"}` for CI readiness polling.
- **cobra** — `ecwid-mock serve [flags]`, `--version` wired to ldflags like `cli/`.

## Route namespace convention (established here — later issues depend on it)

```
/                        -> admin shell (#67)
/api/v3/{storeId}/...    -> simulated Ecwid REST + proxy/501 fallback (#68, #70)
/_mock/...               -> the mock's own control API (#69)
```

The `/_mock/` prefix is reserved so the control plane can never collide with a real Ecwid REST route.

## Out of scope

Admin shell UI, storage endpoints, webhook trigger, proxy, release wiring, docs — separate issues.

## Verification

- `task mock:lint` → 0 issues; `task mock:test` passes (`-race`); root `task lint`/`test`/`tidy` include `mock`.
- `go run ./mock serve --app-url=http://localhost:3000` boots; `curl /_mock/health` → `200 {"status":"ok"}`.
- `--client-secret` shorter than 16 bytes fails at startup with a clear message.
- Ctrl-C shuts down gracefully; secrets/tokens never appear in logs.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a local mock server with configurable app, store, authentication, webhook, proxy, and port settings.
  * Added a health-check endpoint returning JSON status information.
  * Added command-line support for starting the server and displaying its version.
  * Added automatic client-secret generation and secure redaction in logs.

* **Documentation**
  * Added guidance covering mock server structure, configuration, routing, security, and operations.

* **Chores**
  * Integrated mock server linting, testing, and formatting tasks into the project workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->