### PR TITLE
feat(mock): app storage REST endpoints for the JS SDK

### DIFF
--- a/mock/AGENTS.md
+++ b/mock/AGENTS.md
@@ -46,7 +46,8 @@ mock/
     └── server/                 # ServeMux, request logging, graceful lifecycle
         ├── server.go           # New, routes, Run (graceful shutdown)
         ├── middleware.go       # structured slog request logging
-        └── health.go           # GET /_mock/health
+        ├── health.go           # GET /_mock/health
+        └── storage.go          # app-storage REST endpoints (the JS SDK's only HTTP calls)
 ```
 
 Everything lives under `internal/` — this module ships a binary, not a library,
@@ -69,6 +70,7 @@ Precedence is **flags > env > defaults**, matching `config/`'s behavior.
 | `--store-id` | `ECWID_MOCK_STORE_ID` | `1003` | Store ID in the payload |
 | `--auth-mode` | `ECWID_MOCK_AUTH_MODE` | `default` | `default` (hex fragment) \| `enhanced` (AES query) |
 | `--webhook-url` | `ECWID_MOCK_WEBHOOK_URL` | *(optional)* | Where triggered webhooks POST |
+| `--access-token` | `ECWID_MOCK_ACCESS_TOKEN` | *(generated)* | `access_token` issued in the payload; required as `Bearer` on REST calls |
 | `--port` | `ECWID_MOCK_PORT` | `8080` | Listen port |
 | `--proxy-store` / `--proxy-token` | `ECWID_MOCK_PROXY_*` | *(optional)* | Forward unimplemented REST to a real store |
 

--- a/mock/cmd/serve.go
+++ b/mock/cmd/serve.go
@@ -34,6 +34,7 @@ func init() {
 	f.Int("port", config.DefaultPort, "listen port (env: ECWID_MOCK_PORT)")
 	f.String("proxy-store", "", "store ID to forward unimplemented REST calls to (env: ECWID_MOCK_PROXY_STORE)")
 	f.String("proxy-token", "", "access token for the proxy store (env: ECWID_MOCK_PROXY_TOKEN)")
+	f.String("access-token", "", "access_token issued in the payload and required as Bearer on REST calls; generated if unset (env: ECWID_MOCK_ACCESS_TOKEN)")
 
 	rootCmd.AddCommand(serveCmd)
 }

--- a/mock/internal/config/config.go
+++ b/mock/internal/config/config.go
@@ -92,10 +92,10 @@ type Config struct {
 	// ProxyToken is the access token for the proxy store. Optional.
 	ProxyToken string
 
-	// AccessToken is the access_token the mock issues in the iframe payload and
-	// requires as the Bearer credential on simulated REST calls. It reaches the
-	// app through the injected payload, so the developer never configures it by
-	// hand. Generated if not supplied.
+	// AccessToken is the access_token the mock requires as the Bearer credential
+	// on simulated REST calls. Generated if not supplied. The admin shell (#4)
+	// will inject this same value into the iframe payload so the SDK sends it
+	// back automatically; until then it is supplied to the app out of band.
 	AccessToken string
 
 	// SecretGenerated reports whether ClientSecret was generated rather than

--- a/mock/internal/config/config.go
+++ b/mock/internal/config/config.go
@@ -54,6 +54,10 @@ const (
 	// client_secret. Hex-encoding doubles the length, comfortably clearing
 	// MinClientSecretLen.
 	generatedSecretBytes = 16
+
+	// generatedTokenBytes is the number of random bytes used when generating an
+	// access_token. Hex-encoding doubles the resulting string length.
+	generatedTokenBytes = 16
 )
 
 // Config is the mock server's runtime configuration.
@@ -87,6 +91,12 @@ type Config struct {
 
 	// ProxyToken is the access token for the proxy store. Optional.
 	ProxyToken string
+
+	// AccessToken is the access_token the mock issues in the iframe payload and
+	// requires as the Bearer credential on simulated REST calls. It reaches the
+	// app through the injected payload, so the developer never configures it by
+	// hand. Generated if not supplied.
+	AccessToken string
 
 	// SecretGenerated reports whether ClientSecret was generated rather than
 	// supplied. When true, the startup banner prints it so the developer can
@@ -168,6 +178,7 @@ func Load(cmd *cobra.Command) (Config, error) {
 	cfg.WebhookURL = resolveString(cmd, "webhook-url", "ECWID_MOCK_WEBHOOK_URL", "")
 	cfg.ProxyStore = resolveString(cmd, "proxy-store", "ECWID_MOCK_PROXY_STORE", "")
 	cfg.ProxyToken = resolveString(cmd, "proxy-token", "ECWID_MOCK_PROXY_TOKEN", "")
+	cfg.AccessToken = resolveString(cmd, "access-token", "ECWID_MOCK_ACCESS_TOKEN", "")
 
 	port, err := resolvePort(cmd)
 	if err != nil {
@@ -182,6 +193,14 @@ func Load(cmd *cobra.Command) (Config, error) {
 		}
 		cfg.ClientSecret = secret
 		cfg.SecretGenerated = true
+	}
+
+	if cfg.AccessToken == "" {
+		token, err := generateAccessToken()
+		if err != nil {
+			return Config{}, fmt.Errorf("generate access_token: %w", err)
+		}
+		cfg.AccessToken = token
 	}
 
 	return cfg, nil
@@ -224,7 +243,17 @@ func resolvePort(cmd *cobra.Command) (int, error) {
 // generateSecret returns a hex-encoded random client_secret of at least
 // MinClientSecretLen bytes.
 func generateSecret() (string, error) {
-	buf := make([]byte, generatedSecretBytes)
+	return randomHex(generatedSecretBytes)
+}
+
+// generateAccessToken returns a hex-encoded random access_token.
+func generateAccessToken() (string, error) {
+	return randomHex(generatedTokenBytes)
+}
+
+// randomHex returns the hex encoding of n cryptographically random bytes.
+func randomHex(n int) (string, error) {
+	buf := make([]byte, n)
 	if _, err := rand.Read(buf); err != nil {
 		return "", err
 	}

--- a/mock/internal/config/config_test.go
+++ b/mock/internal/config/config_test.go
@@ -21,6 +21,7 @@ func newCmd() *cobra.Command {
 	f.Int("port", DefaultPort, "")
 	f.String("proxy-store", "", "")
 	f.String("proxy-token", "", "")
+	f.String("access-token", "", "")
 	return cmd
 }
 
@@ -52,6 +53,27 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 	if len(cfg.ClientSecret) < MinClientSecretLen {
 		t.Errorf("generated ClientSecret len = %d, want >= %d", len(cfg.ClientSecret), MinClientSecretLen)
+	}
+	if cfg.AccessToken == "" {
+		t.Error("AccessToken is empty, want a generated token when none supplied")
+	}
+}
+
+func TestLoad_SuppliedAccessToken(t *testing.T) {
+	cmd := newCmd()
+	if err := cmd.Flags().Set("app-url", "http://localhost:3000"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("access-token", "supplied-token"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cmd)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.AccessToken != "supplied-token" {
+		t.Errorf("AccessToken = %q, want supplied value", cfg.AccessToken)
 	}
 }
 

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -45,10 +45,11 @@ const shutdownTimeout = 10 * time.Second
 
 // Server wraps the HTTP server and its configuration.
 type Server struct {
-	cfg  config.Config
-	log  *slog.Logger
-	mux  *http.ServeMux
-	http *http.Server
+	cfg   config.Config
+	log   *slog.Logger
+	mux   *http.ServeMux
+	http  *http.Server
+	store *appStorage
 }
 
 // New builds a Server with all routes registered. The provided logger is used
@@ -62,9 +63,10 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 	addr := net.JoinHostPort("", strconv.Itoa(cfg.Port))
 
 	s := &Server{
-		cfg: cfg,
-		log: log,
-		mux: mux,
+		cfg:   cfg,
+		log:   log,
+		mux:   mux,
+		store: newAppStorage(),
 	}
 
 	s.routes()
@@ -88,6 +90,14 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 // control endpoints are added by later issues.
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /_mock/health", handleHealth)
+
+	// Simulated Ecwid REST: the app-storage endpoints the JS SDK actually calls
+	// over HTTP (getAppStorage/setAppStorage and the public-config variants).
+	s.mux.HandleFunc("GET /api/v3/{storeId}/storage", s.handleStorageList)
+	s.mux.HandleFunc("GET /api/v3/{storeId}/storage/{key}", s.handleStorageGet)
+	s.mux.HandleFunc("PUT /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
+	s.mux.HandleFunc("POST /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
+	s.mux.HandleFunc("DELETE /api/v3/{storeId}/storage/{key}", s.handleStorageDelete)
 }
 
 // Run starts the server and blocks until ctx is canceled (e.g. on SIGINT or

--- a/mock/internal/server/storage.go
+++ b/mock/internal/server/storage.go
@@ -103,6 +103,12 @@ func valueLimit(key string) int {
 // constant-time to avoid leaking the token through timing.
 func (s *Server) authorized(r *http.Request) bool {
 	const prefix = "Bearer "
+	// An empty configured token would otherwise accept "Authorization: Bearer "
+	// (empty credential), so a Server built with a bare config.Config{} would run
+	// with effectively no auth. Reject that explicitly.
+	if s.cfg.AccessToken == "" {
+		return false
+	}
 	h := r.Header.Get("Authorization")
 	if !strings.HasPrefix(h, prefix) {
 		return false
@@ -155,7 +161,7 @@ func (s *Server) handleStoragePut(w http.ResponseWriter, r *http.Request) {
 	// buffering an unbounded body.
 	body, err := io.ReadAll(io.LimitReader(r.Body, int64(limit)+1))
 	if err != nil {
-		writeStorageError(w, http.StatusBadRequest, "read request body")
+		writeStorageError(w, http.StatusBadRequest, "failed to read request body")
 		return
 	}
 	if len(body) > limit {

--- a/mock/internal/server/storage.go
+++ b/mock/internal/server/storage.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// App-storage value size limits. Ecwid caps private keys at 1 MB and the
+// reserved public key at 256 KB; the mock enforces the same so a developer hits
+// the limit locally before production does.
+const (
+	maxPrivateValueBytes = 1 << 20   // 1 MB
+	maxPublicValueBytes  = 256 << 10 // 256 KB
+
+	// reservedPublicKey is the single key whose value the SDK exposes to the
+	// storefront via getAppPublicConfig/setAppPublicConfig. It rides the same
+	// routes as any other key but carries the smaller size limit.
+	reservedPublicKey = "public"
+)
+
+// storageEntry is the wire shape of a single stored key/value pair. Values are
+// opaque strings kept verbatim — the mock never parses or coerces them.
+type storageEntry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// appStorage is the mock's in-memory app-storage backend, keyed by store ID and
+// then by key. A fresh, empty store per process run is intentional: the mock is
+// a dev tool. It is safe for concurrent use.
+type appStorage struct {
+	mu   sync.RWMutex
+	data map[string]map[string]string // storeID -> key -> raw value
+}
+
+// newAppStorage returns an empty app-storage backend.
+func newAppStorage() *appStorage {
+	return &appStorage{data: make(map[string]map[string]string)}
+}
+
+// get returns the raw value for a key and whether it was present.
+func (s *appStorage) get(storeID, key string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.data[storeID][key]
+	return v, ok
+}
+
+// all returns every entry for a store, sorted by key for a stable response.
+// The result is always non-nil so it encodes as [] rather than null.
+func (s *appStorage) all(storeID string) []storageEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	store := s.data[storeID]
+	keys := make([]string, 0, len(store))
+	for k := range store {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	entries := make([]storageEntry, 0, len(keys))
+	for _, k := range keys {
+		entries = append(entries, storageEntry{Key: k, Value: store[k]})
+	}
+	return entries
+}
+
+// set stores value verbatim under key for the given store.
+func (s *appStorage) set(storeID, key, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.data[storeID] == nil {
+		s.data[storeID] = make(map[string]string)
+	}
+	s.data[storeID][key] = value
+}
+
+// delete removes key from the given store. Deleting an absent key is a no-op.
+func (s *appStorage) delete(storeID, key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data[storeID], key)
+}
+
+// valueLimit returns the byte limit for a key: the smaller public-config limit
+// for the reserved "public" key, the private limit otherwise.
+func valueLimit(key string) int {
+	if key == reservedPublicKey {
+		return maxPublicValueBytes
+	}
+	return maxPrivateValueBytes
+}
+
+// authorized reports whether the request carries the access_token the mock
+// issued, as an "Authorization: Bearer <token>" header. The comparison is
+// constant-time to avoid leaking the token through timing.
+func (s *Server) authorized(r *http.Request) bool {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, prefix) {
+		return false
+	}
+	got := strings.TrimPrefix(h, prefix)
+	return subtle.ConstantTimeCompare([]byte(got), []byte(s.cfg.AccessToken)) == 1
+}
+
+// handleStorageList serves GET /api/v3/{storeId}/storage: every stored entry as
+// a JSON array.
+func (s *Server) handleStorageList(w http.ResponseWriter, r *http.Request) {
+	if !s.authorized(r) {
+		writeStorageError(w, http.StatusUnauthorized, "invalid or missing access token")
+		return
+	}
+	writeJSON(w, http.StatusOK, s.store.all(r.PathValue("storeId")))
+}
+
+// handleStorageGet serves GET /api/v3/{storeId}/storage/{key}: the single entry,
+// or 404 if the key is absent. The SDK maps that 404 to null, so it must be a
+// real 404 and never a 200 with an empty value.
+func (s *Server) handleStorageGet(w http.ResponseWriter, r *http.Request) {
+	if !s.authorized(r) {
+		writeStorageError(w, http.StatusUnauthorized, "invalid or missing access token")
+		return
+	}
+	key := r.PathValue("key")
+	value, ok := s.store.get(r.PathValue("storeId"), key)
+	if !ok {
+		writeStorageError(w, http.StatusNotFound, fmt.Sprintf("no value stored for key %q", key))
+		return
+	}
+	writeJSON(w, http.StatusOK, storageEntry{Key: key, Value: value})
+}
+
+// handleStoragePut serves PUT and POST /api/v3/{storeId}/storage/{key}. The
+// request body is the raw value string, stored verbatim — not a {"value":...}
+// wrapper. Content-Type is deliberately not validated: the SDK's ajax() sends a
+// literal "Content-type: undefined", and rejecting it would reject the SDK's own
+// writes.
+func (s *Server) handleStoragePut(w http.ResponseWriter, r *http.Request) {
+	if !s.authorized(r) {
+		writeStorageError(w, http.StatusUnauthorized, "invalid or missing access token")
+		return
+	}
+	key := r.PathValue("key")
+	limit := valueLimit(key)
+
+	// Read one byte past the limit so an over-limit write is detected without
+	// buffering an unbounded body.
+	body, err := io.ReadAll(io.LimitReader(r.Body, int64(limit)+1))
+	if err != nil {
+		writeStorageError(w, http.StatusBadRequest, "read request body")
+		return
+	}
+	if len(body) > limit {
+		writeStorageError(w, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("value for key %q exceeds the %d-byte limit", key, limit))
+		return
+	}
+
+	s.store.set(r.PathValue("storeId"), key, string(body))
+	writeJSON(w, http.StatusOK, successResponse())
+}
+
+// handleStorageDelete serves DELETE /api/v3/{storeId}/storage/{key}. Deleting a
+// missing key still reports success, matching Ecwid's idempotent delete.
+func (s *Server) handleStorageDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.authorized(r) {
+		writeStorageError(w, http.StatusUnauthorized, "invalid or missing access token")
+		return
+	}
+	s.store.delete(r.PathValue("storeId"), r.PathValue("key"))
+	writeJSON(w, http.StatusOK, successResponse())
+}
+
+// successResponse is the {"success": true} body the write and delete routes
+// return.
+func successResponse() map[string]bool {
+	return map[string]bool{"success": true}
+}
+
+// writeJSON writes v as a JSON response with the given status.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	// A client that has gone away is the only realistic encode failure and there
+	// is nothing actionable to do about it here.
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeStorageError writes a JSON error body with the given status.
+func writeStorageError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"errorMessage": msg})
+}

--- a/mock/internal/server/storage_test.go
+++ b/mock/internal/server/storage_test.go
@@ -185,6 +185,19 @@ func TestStorage_Unauthorized(t *testing.T) {
 	}
 }
 
+// TestStorage_EmptyConfiguredTokenRejects asserts a Server built with no access
+// token rejects every request, including a bare "Authorization: Bearer " header,
+// rather than running with effectively no auth.
+func TestStorage_EmptyConfiguredTokenRejects(t *testing.T) {
+	srv := New(config.Config{Port: 0}, discardLogger())
+
+	bare := httptest.NewRequest(http.MethodGet, path("k"), http.NoBody)
+	bare.Header.Set("Authorization", "Bearer ")
+	if rec := do(srv, bare); rec.Code != http.StatusUnauthorized {
+		t.Errorf("bare Bearer with empty configured token status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
 // TestStorage_List asserts the list route returns every entry as a sorted JSON
 // array, and an empty store returns [] rather than null.
 func TestStorage_List(t *testing.T) {

--- a/mock/internal/server/storage_test.go
+++ b/mock/internal/server/storage_test.go
@@ -1,0 +1,253 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+const (
+	testToken   = "test-access-token-abc123"
+	testStoreID = "1003"
+)
+
+// newStorageServer builds a server with a known access token for storage tests.
+func newStorageServer() *Server {
+	return New(config.Config{Port: 0, AccessToken: testToken}, discardLogger())
+}
+
+// storageReq builds an authorized request against the store's storage routes.
+func storageReq(method, target string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	return req
+}
+
+func do(srv *Server, req *http.Request) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func path(key string) string {
+	if key == "" {
+		return "/api/v3/" + testStoreID + "/storage"
+	}
+	return "/api/v3/" + testStoreID + "/storage/" + key
+}
+
+// TestStorage_RawBodyRoundTrip asserts the body is stored verbatim as the value,
+// not wrapped in {"value": ...}.
+func TestStorage_RawBodyRoundTrip(t *testing.T) {
+	srv := newStorageServer()
+
+	put := do(srv, storageReq(http.MethodPut, path("greeting"), strings.NewReader("hello")))
+	if put.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want %d", put.Code, http.StatusOK)
+	}
+	var ok map[string]bool
+	if err := json.NewDecoder(put.Body).Decode(&ok); err != nil {
+		t.Fatalf("decode PUT body: %v", err)
+	}
+	if !ok["success"] {
+		t.Errorf("PUT body = %v, want success=true", ok)
+	}
+
+	get := do(srv, storageReq(http.MethodGet, path("greeting"), http.NoBody))
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want %d", get.Code, http.StatusOK)
+	}
+	var entry storageEntry
+	if err := json.NewDecoder(get.Body).Decode(&entry); err != nil {
+		t.Fatalf("decode GET body: %v", err)
+	}
+	if entry.Key != "greeting" || entry.Value != "hello" {
+		t.Errorf("entry = %+v, want {greeting hello}", entry)
+	}
+}
+
+// TestStorage_MissingKey404 asserts a real 404 for an absent key — the SDK maps
+// it to null.
+func TestStorage_MissingKey404(t *testing.T) {
+	srv := newStorageServer()
+
+	rec := do(srv, storageReq(http.MethodGet, path("installed"), http.NoBody))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET missing key status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+// TestStorage_ContentTypeUndefined asserts the SDK's literal
+// "Content-type: undefined" header is accepted, since Content-Type is not
+// validated.
+func TestStorage_ContentTypeUndefined(t *testing.T) {
+	srv := newStorageServer()
+
+	req := storageReq(http.MethodPut, path("k"), strings.NewReader("v"))
+	req.Header.Set("Content-Type", "undefined")
+	rec := do(srv, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT with Content-type: undefined status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestStorage_OverLimit asserts private (>1MB) and public (>256KB) over-limit
+// writes are rejected.
+func TestStorage_OverLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		size int
+	}{
+		{"private", "big", maxPrivateValueBytes + 1},
+		{"public", reservedPublicKey, maxPublicValueBytes + 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newStorageServer()
+			body := bytes.Repeat([]byte("a"), tt.size)
+			rec := do(srv, storageReq(http.MethodPut, path(tt.key), bytes.NewReader(body)))
+			if rec.Code != http.StatusRequestEntityTooLarge {
+				t.Fatalf("over-limit PUT status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+			}
+		})
+	}
+}
+
+// TestStorage_AtLimit asserts a write exactly at the limit is accepted.
+func TestStorage_AtLimit(t *testing.T) {
+	srv := newStorageServer()
+	body := bytes.Repeat([]byte("a"), maxPublicValueBytes)
+	rec := do(srv, storageReq(http.MethodPut, path(reservedPublicKey), bytes.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("at-limit PUT status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestStorage_PublicKeyRoundTrips asserts the reserved "public" key uses the
+// same routes as any other key.
+func TestStorage_PublicKeyRoundTrips(t *testing.T) {
+	srv := newStorageServer()
+
+	value := `{"theme":"dark"}`
+	if rec := do(srv, storageReq(http.MethodPut, path(reservedPublicKey), strings.NewReader(value))); rec.Code != http.StatusOK {
+		t.Fatalf("PUT public status = %d, want %d", rec.Code, http.StatusOK)
+	}
+
+	get := do(srv, storageReq(http.MethodGet, path(reservedPublicKey), http.NoBody))
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET public status = %d, want %d", get.Code, http.StatusOK)
+	}
+	var entry storageEntry
+	if err := json.NewDecoder(get.Body).Decode(&entry); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if entry.Value != value {
+		t.Errorf("public value = %q, want %q", entry.Value, value)
+	}
+}
+
+// TestStorage_Unauthorized asserts wrong and missing bearer tokens are rejected
+// with 401 across all storage routes.
+func TestStorage_Unauthorized(t *testing.T) {
+	srv := newStorageServer()
+	// Seed a key so a GET would otherwise succeed.
+	srv.store.set(testStoreID, "seeded", "v")
+
+	cases := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"no header", httptest.NewRequest(http.MethodGet, path("seeded"), http.NoBody)},
+		{"list no header", httptest.NewRequest(http.MethodGet, path(""), http.NoBody)},
+		{"put no header", httptest.NewRequest(http.MethodPut, path("k"), strings.NewReader("v"))},
+		{"delete no header", httptest.NewRequest(http.MethodDelete, path("seeded"), http.NoBody)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if rec := do(srv, tc.req); rec.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+
+	wrong := httptest.NewRequest(http.MethodGet, path("seeded"), http.NoBody)
+	wrong.Header.Set("Authorization", "Bearer not-the-token")
+	if rec := do(srv, wrong); rec.Code != http.StatusUnauthorized {
+		t.Errorf("wrong token status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+// TestStorage_List asserts the list route returns every entry as a sorted JSON
+// array, and an empty store returns [] rather than null.
+func TestStorage_List(t *testing.T) {
+	srv := newStorageServer()
+
+	empty := do(srv, storageReq(http.MethodGet, path(""), http.NoBody))
+	if empty.Code != http.StatusOK {
+		t.Fatalf("empty list status = %d, want %d", empty.Code, http.StatusOK)
+	}
+	if got := strings.TrimSpace(empty.Body.String()); got != "[]" {
+		t.Errorf("empty list body = %q, want []", got)
+	}
+
+	for k, v := range map[string]string{"b": "2", "a": "1"} {
+		if rec := do(srv, storageReq(http.MethodPut, path(k), strings.NewReader(v))); rec.Code != http.StatusOK {
+			t.Fatalf("seed PUT %q status = %d", k, rec.Code)
+		}
+	}
+
+	rec := do(srv, storageReq(http.MethodGet, path(""), http.NoBody))
+	var entries []storageEntry
+	if err := json.NewDecoder(rec.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	want := []storageEntry{{Key: "a", Value: "1"}, {Key: "b", Value: "2"}}
+	if fmt.Sprintf("%v", entries) != fmt.Sprintf("%v", want) {
+		t.Errorf("list = %v, want %v", entries, want)
+	}
+}
+
+// TestStorage_Delete asserts a deleted key subsequently 404s, and deleting an
+// absent key still reports success.
+func TestStorage_Delete(t *testing.T) {
+	srv := newStorageServer()
+
+	if rec := do(srv, storageReq(http.MethodPut, path("k"), strings.NewReader("v"))); rec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d", rec.Code)
+	}
+	if rec := do(srv, storageReq(http.MethodDelete, path("k"), http.NoBody)); rec.Code != http.StatusOK {
+		t.Fatalf("DELETE status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec := do(srv, storageReq(http.MethodGet, path("k"), http.NoBody)); rec.Code != http.StatusNotFound {
+		t.Errorf("GET after delete status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+	// Deleting an absent key is idempotent.
+	if rec := do(srv, storageReq(http.MethodDelete, path("k"), http.NoBody)); rec.Code != http.StatusOK {
+		t.Errorf("DELETE absent key status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+// TestStorage_Post asserts POST writes identically to PUT.
+func TestStorage_Post(t *testing.T) {
+	srv := newStorageServer()
+
+	if rec := do(srv, storageReq(http.MethodPost, path("k"), strings.NewReader("posted"))); rec.Code != http.StatusOK {
+		t.Fatalf("POST status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	get := do(srv, storageReq(http.MethodGet, path("k"), http.NoBody))
+	var entry storageEntry
+	if err := json.NewDecoder(get.Body).Decode(&entry); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if entry.Value != "posted" {
+		t.Errorf("value = %q, want posted", entry.Value)
+	}
+}


### PR DESCRIPTION
Implements the app-storage REST endpoints the Native App JS SDK calls over HTTP, so `EcwidApp.getAppStorage` / `setAppStorage` / `getAppPublicConfig` / `setAppPublicConfig` work against the mock. These are the **only** SDK methods that make real HTTP calls — everything else is postMessage or local state.

## Endpoints (under `/api/v3/{storeId}/storage[/{key}]`)

| Method | Path | Behavior |
|---|---|---|
| `GET` | `/storage` | All keys → `[{"key","value"}, …]` (sorted) |
| `GET` | `/storage/{key}` | `{"key","value"}`; **404 if absent** |
| `PUT`/`POST` | `/storage/{key}` | Store raw body → `{"success": true}` |
| `DELETE` | `/storage/{key}` | Delete → `{"success": true}` |

## Traps handled (per the issue's research)

- **Raw-value body**, stored verbatim — not a `{"value":…}` wrapper.
- **Real 404** on a missing key (the SDK maps it to `null`; the sample app's new-vs-returning-user branch depends on it).
- **No Content-Type validation** — the SDK's `ajax()` sends a literal `Content-type: undefined`; validating would reject its own writes.
- **`public` is a reserved key** riding the same routes, with the smaller 256 KB limit.

## Semantics

- Size limits enforced: private **1 MB**, public **256 KB** → `413` over-limit (body read is capped at limit+1, never unbounded).
- Values are opaque strings, never coerced.
- In-memory `map[storeID]map[key]value` behind an `RWMutex`; fresh store per run. Multi-store isn't structurally excluded.

## Auth

Validates `Authorization: Bearer <token>` against the `access_token` the mock issues (new `--access-token` / `ECWID_MOCK_ACCESS_TOKEN`, generated if unset), constant-time compare; **401** otherwise. Token is never logged. `#4`'s admin shell will inject this same `cfg.AccessToken` into the iframe payload.

## Tests

Raw-body round-trip, missing-key 404, `Content-type: undefined` accepted, over-limit 413 (private + public), at-limit accepted, `public` round-trip, missing/wrong bearer 401, list (incl. empty → `[]`), delete→404 + idempotent delete, POST≡PUT. `task mock:lint` / `task mock:test` pass; verified end-to-end with curl against a running server.

Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated REST storage endpoints for listing, retrieving, creating, updating, and deleting key-value entries.
  * Added configurable access-token support through the command line or environment, with automatic generation when omitted.
  * Added storage size limits, including special handling for the `public` key.

* **Documentation**
  * Updated mock server documentation with storage endpoints and access-token configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->