### PR TITLE
feat(mock): REST proxy with 501 fallback, read-only by default

### DIFF
--- a/mock/AGENTS.md
+++ b/mock/AGENTS.md
@@ -21,6 +21,18 @@ exactly one namespace each.
 |--------|---------|-------------|
 | `/` | Admin shell — the developer-facing UI that hosts the app iframe | #4 |
 | `/api/v3/{storeId}/...` | Simulated Ecwid REST; proxy or `501` fallback for unimplemented routes | #5, #7 |
+
+**REST fallback (`internal/server/proxy.go`).** Unimplemented REST routes return an
+informative `501` naming the endpoint and the `--proxy-store`/`--proxy-token`
+remedy. With proxying configured they forward to
+`https://app.ecwid.com/api/v3/{proxyStore}/…`, rewriting the store ID and
+swapping the `Authorization` bearer for the proxy token. Proxying uses a plain
+`http.Client` (the `ecwid/internal/api` transport is JSON-oriented and its retry
+transport is unexported — reusing it would widen that module's exported surface,
+which the "CRUCIAL RULE" forbids). `--proxy-readonly` (default **true**) blocks
+proxied mutations with `403`. **`/storage` is always served locally**, even when
+proxying, so dev scratch state never lands in the real store's app storage —
+enforced in the fallback handler and by ServeMux route specificity.
 | `/_mock/...` | The mock's own control API (health, webhook trigger, …) | #6 |
 
 The `/_mock/` prefix is reserved so the mock's control plane can **never collide
@@ -97,7 +109,8 @@ Precedence is **flags > env > defaults**, matching `config/`'s behavior.
 | `--webhook-url` | `ECWID_MOCK_WEBHOOK_URL` | *(optional)* | Where triggered webhooks POST |
 | `--access-token` | `ECWID_MOCK_ACCESS_TOKEN` | *(generated)* | `access_token` issued in the payload; required as `Bearer` on REST calls |
 | `--port` | `ECWID_MOCK_PORT` | `8080` | Listen port |
-| `--proxy-store` / `--proxy-token` | `ECWID_MOCK_PROXY_*` | *(optional)* | Forward unimplemented REST to a real store |
+| `--proxy-store` / `--proxy-token` | `ECWID_MOCK_PROXY_*` | *(optional)* | Forward unimplemented REST to a real store (both required together) |
+| `--proxy-readonly` | `ECWID_MOCK_PROXY_READONLY` | `true` | Only proxy `GET`/`HEAD`; mutations → `403`. Off = proxied writes hit the real store |
 
 `--client-secret` **must be ≥16 bytes** — `appauth.Encrypt` derives an AES-128
 key from `client_secret[:16]`. It is validated at startup (referencing

--- a/mock/cmd/serve.go
+++ b/mock/cmd/serve.go
@@ -35,6 +35,7 @@ func init() {
 	f.String("proxy-store", "", "store ID to forward unimplemented REST calls to (env: ECWID_MOCK_PROXY_STORE)")
 	f.String("proxy-token", "", "access token for the proxy store (env: ECWID_MOCK_PROXY_TOKEN)")
 	f.String("access-token", "", "access_token issued in the payload and required as Bearer on REST calls; generated if unset (env: ECWID_MOCK_ACCESS_TOKEN)")
+	f.Bool("proxy-readonly", config.DefaultProxyReadonly, "only proxy GET/HEAD; block proxied mutations (they hit the real store and fire real webhooks) (env: ECWID_MOCK_PROXY_READONLY)")
 
 	rootCmd.AddCommand(serveCmd)
 }
@@ -73,6 +74,25 @@ func printBanner(w io.Writer, cfg *config.Config) error {
 		banner += fmt.Sprintf("  client_secret (generated): %s\n", cfg.ClientSecret) +
 			"  ^ configure your app with this secret; override with --client-secret\n"
 	}
+	banner += proxyBanner(cfg)
 	_, err := io.WriteString(w, banner)
 	return err
+}
+
+// proxyBanner returns the prominent proxy warning block, or "" when proxying is
+// off. It names the target store and read-only state so forwarding is never a
+// silent surprise, and it prints the proxy token only in redacted form.
+func proxyBanner(cfg *config.Config) string {
+	if !cfg.ProxyEnabled() {
+		return ""
+	}
+	b := "\n  ⚠ PROXY ENABLED — unimplemented REST endpoints forward to a REAL store\n" +
+		fmt.Sprintf("     target store: %s\n", cfg.ProxyStore) +
+		fmt.Sprintf("     token:        %s\n", cfg.RedactedProxyToken())
+	if cfg.ProxyReadonly {
+		b += "     read-only:    true — GET/HEAD proxy; writes blocked (--proxy-readonly=false to allow)\n"
+	} else {
+		b += "     read-only:    FALSE — proxied POST/PUT/DELETE MUTATE the real store and fire REAL webhooks\n"
+	}
+	return b
 }

--- a/mock/cmd/serve_test.go
+++ b/mock/cmd/serve_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+func TestPrintBanner_NoProxy(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := config.Config{AppURL: "http://localhost:3000", StoreID: "1003", AuthMode: "default", ClientID: "mock-app", Port: 8080}
+	if err := printBanner(&buf, &cfg); err != nil {
+		t.Fatalf("printBanner: %v", err)
+	}
+	if strings.Contains(buf.String(), "PROXY ENABLED") {
+		t.Errorf("banner shows proxy block when proxying is off:\n%s", buf.String())
+	}
+}
+
+func TestPrintBanner_ProxyEnabled_NamesStoreAndRedactsToken(t *testing.T) {
+	const token = "super-secret-proxy-token"
+	var buf bytes.Buffer
+	cfg := config.Config{
+		AppURL: "http://localhost:3000", StoreID: "1003", AuthMode: "default", ClientID: "mock-app", Port: 8080,
+		ProxyStore: "42", ProxyToken: token, ProxyReadonly: true,
+	}
+	if err := printBanner(&buf, &cfg); err != nil {
+		t.Fatalf("printBanner: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "PROXY ENABLED") {
+		t.Errorf("banner missing proxy block:\n%s", out)
+	}
+	if !strings.Contains(out, "42") {
+		t.Errorf("banner does not name the target store:\n%s", out)
+	}
+	if strings.Contains(out, token) {
+		t.Errorf("banner leaked the proxy token:\n%s", out)
+	}
+	if !strings.Contains(out, "read-only:    true") {
+		t.Errorf("banner does not state read-only status:\n%s", out)
+	}
+}
+
+func TestPrintBanner_ProxyWritable_WarnsLoudly(t *testing.T) {
+	var buf bytes.Buffer
+	cfg := config.Config{
+		AppURL: "http://localhost:3000", StoreID: "1003", AuthMode: "default", ClientID: "mock-app", Port: 8080,
+		ProxyStore: "42", ProxyToken: "t", ProxyReadonly: false,
+	}
+	if err := printBanner(&buf, &cfg); err != nil {
+		t.Fatalf("printBanner: %v", err)
+	}
+	if !strings.Contains(buf.String(), "MUTATE") {
+		t.Errorf("writable proxy banner does not warn about real mutations:\n%s", buf.String())
+	}
+}

--- a/mock/internal/config/config.go
+++ b/mock/internal/config/config.go
@@ -37,6 +37,11 @@ const (
 	// DefaultPort is the default listen port.
 	DefaultPort = 8080
 
+	// DefaultProxyReadonly is the default for --proxy-readonly. It is true on
+	// purpose: a proxied write mutates a REAL store and fires REAL webhooks from
+	// it, so the mock refuses mutations until the developer explicitly opts in.
+	DefaultProxyReadonly = true
+
 	// AuthModeDefault is Default User Auth: a hex-encoded plaintext payload in
 	// the URL fragment (see ecwid/appauth).
 	AuthModeDefault = "default"
@@ -98,6 +103,12 @@ type Config struct {
 	// back automatically; until then it is supplied to the app out of band.
 	AccessToken string
 
+	// ProxyReadonly gates proxied mutations. When true (the default), only
+	// GET/HEAD are forwarded and write methods return 403 — proxied writes
+	// mutate a REAL store and fire REAL webhooks from it, so the safe default is
+	// "cannot wreck your store". Set false to allow mutating proxy requests.
+	ProxyReadonly bool
+
 	// SecretGenerated reports whether ClientSecret was generated rather than
 	// supplied. When true, the startup banner prints it so the developer can
 	// configure their app to match.
@@ -124,6 +135,12 @@ func (c *Config) RedactedProxyToken() string {
 func redact(secret string) string {
 	rc := appconfig.Config{Token: secret}
 	return rc.RedactedToken()
+}
+
+// ProxyEnabled reports whether request forwarding is active. Both the target
+// store and its token are required; one without the other cannot proxy.
+func (c *Config) ProxyEnabled() bool {
+	return c.ProxyStore != "" && c.ProxyToken != ""
 }
 
 // Validate checks required fields and value constraints.
@@ -157,6 +174,12 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Sprintf("--port %d is out of range (1-65535)", c.Port))
 	}
 
+	// Proxying needs both halves: a target store and its token. One without the
+	// other is a misconfiguration, not a partial proxy.
+	if (c.ProxyStore == "") != (c.ProxyToken == "") {
+		errs = append(errs, "--proxy-store and --proxy-token must be set together to enable proxying")
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("config validation: %s", strings.Join(errs, "; "))
 	}
@@ -170,10 +193,11 @@ func (c *Config) Validate() error {
 // SecretGenerated is set.
 func Load(cmd *cobra.Command) (Config, error) {
 	cfg := Config{
-		ClientID: DefaultClientID,
-		StoreID:  DefaultStoreID,
-		AuthMode: DefaultAuthMode,
-		Port:     DefaultPort,
+		ClientID:      DefaultClientID,
+		StoreID:       DefaultStoreID,
+		AuthMode:      DefaultAuthMode,
+		Port:          DefaultPort,
+		ProxyReadonly: DefaultProxyReadonly,
 	}
 
 	cfg.AppURL = resolveString(cmd, "app-url", "ECWID_MOCK_APP_URL", "")
@@ -191,6 +215,12 @@ func Load(cmd *cobra.Command) (Config, error) {
 		return Config{}, err
 	}
 	cfg.Port = port
+
+	readonly, err := resolveBool(cmd, "proxy-readonly", "ECWID_MOCK_PROXY_READONLY", DefaultProxyReadonly)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.ProxyReadonly = readonly
 
 	if cfg.ClientSecret == "" {
 		secret, err := generateSecret()
@@ -223,6 +253,29 @@ func resolveString(cmd *cobra.Command, flag, env, def string) string {
 		return v
 	}
 	return def
+}
+
+// resolveBool applies flags > env > default for a boolean value. The flag wins
+// only when explicitly set; otherwise the env var is parsed with
+// strconv.ParseBool ("1", "t", "true", "0", "f", "false", …); otherwise def.
+func resolveBool(cmd *cobra.Command, flag, env string, def bool) (bool, error) {
+	if cmd != nil {
+		if f := cmd.Flags().Lookup(flag); f != nil && f.Changed {
+			b, err := cmd.Flags().GetBool(flag)
+			if err != nil {
+				return false, fmt.Errorf("parse --%s: %w", flag, err)
+			}
+			return b, nil
+		}
+	}
+	if v, ok := os.LookupEnv(env); ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return false, fmt.Errorf("parse %s %q: %w", env, v, err)
+		}
+		return b, nil
+	}
+	return def, nil
 }
 
 // resolvePort applies flags > env > default for the listen port.

--- a/mock/internal/config/config_test.go
+++ b/mock/internal/config/config_test.go
@@ -22,6 +22,7 @@ func newCmd() *cobra.Command {
 	f.String("proxy-store", "", "")
 	f.String("proxy-token", "", "")
 	f.String("access-token", "", "")
+	f.Bool("proxy-readonly", DefaultProxyReadonly, "")
 	return cmd
 }
 
@@ -216,6 +217,105 @@ func TestValidate(t *testing.T) {
 				t.Errorf("Validate() = %v, want error containing %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestLoad_ProxyReadonlyDefaultsTrue(t *testing.T) {
+	cmd := newCmd()
+	if err := cmd.Flags().Set("app-url", "http://localhost:3000"); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cmd)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.ProxyReadonly {
+		t.Error("ProxyReadonly = false, want true by default (writes must be blocked unless opted in)")
+	}
+}
+
+func TestLoad_ProxyReadonlyResolution(t *testing.T) {
+	t.Run("flag false wins over env true", func(t *testing.T) {
+		t.Setenv("ECWID_MOCK_PROXY_READONLY", "true")
+		cmd := newCmd()
+		if err := cmd.Flags().Set("app-url", "http://localhost:3000"); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd.Flags().Set("proxy-readonly", "false"); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := Load(cmd)
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.ProxyReadonly {
+			t.Error("ProxyReadonly = true, want flag false to win over env")
+		}
+	})
+
+	t.Run("env false overrides default", func(t *testing.T) {
+		t.Setenv("ECWID_MOCK_PROXY_READONLY", "false")
+		cfg, err := Load(newCmd())
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if cfg.ProxyReadonly {
+			t.Error("ProxyReadonly = true, want env false to override default")
+		}
+	})
+
+	t.Run("invalid env is an error", func(t *testing.T) {
+		t.Setenv("ECWID_MOCK_PROXY_READONLY", "maybe")
+		if _, err := Load(newCmd()); err == nil {
+			t.Fatal("Load: want error for non-boolean ECWID_MOCK_PROXY_READONLY, got nil")
+		}
+	})
+}
+
+func TestValidate_ProxyStoreAndTokenPairing(t *testing.T) {
+	validSecret := "0123456789abcdef"
+	base := func() Config {
+		return Config{AppURL: "http://localhost:3000", ClientSecret: validSecret, AuthMode: AuthModeDefault, Port: 8080}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{name: "neither set", mutate: func(*Config) {}},
+		{name: "both set", mutate: func(c *Config) { c.ProxyStore = "42"; c.ProxyToken = "t" }},
+		{name: "store without token", mutate: func(c *Config) { c.ProxyStore = "42" }, wantErr: "must be set together"},
+		{name: "token without store", mutate: func(c *Config) { c.ProxyToken = "t" }, wantErr: "must be set together"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base()
+			tt.mutate(&cfg)
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() = %v, want error containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProxyEnabled(t *testing.T) {
+	if (&Config{}).ProxyEnabled() {
+		t.Error("ProxyEnabled() = true for empty config, want false")
+	}
+	if (&Config{ProxyStore: "42"}).ProxyEnabled() {
+		t.Error("ProxyEnabled() = true with store but no token, want false")
+	}
+	if !(&Config{ProxyStore: "42", ProxyToken: "t"}).ProxyEnabled() {
+		t.Error("ProxyEnabled() = false with both set, want true")
 	}
 }
 

--- a/mock/internal/server/proxy.go
+++ b/mock/internal/server/proxy.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultUpstreamBase is the real Ecwid API origin proxied requests target.
+	// Only the scheme+host are used; the path is rebuilt per request with the
+	// proxy store ID swapped in.
+	defaultUpstreamBase = "https://app.ecwid.com"
+
+	// proxyTimeout bounds a single forwarded request end to end so a slow or
+	// hung upstream cannot pin a mock connection open indefinitely.
+	proxyTimeout = 30 * time.Second
+
+	// apiPrefix is the REST path prefix shared by the mock and the real API.
+	apiPrefix = "/api/v3/"
+)
+
+// hopByHopHeaders are connection-scoped headers that must not be forwarded
+// between the client<->mock and mock<->upstream hops (RFC 7230 §6.1).
+var hopByHopHeaders = map[string]struct{}{
+	"Connection":          {},
+	"Proxy-Connection":    {},
+	"Keep-Alive":          {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+	"Te":                  {},
+	"Trailer":             {},
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+}
+
+// handleRESTFallback backstops every /api/v3/{storeId}/... route the mock does
+// not simulate locally. With proxying configured it forwards to the real store
+// (subject to the read-only gate); otherwise it returns an informative 501.
+//
+// /storage is always served locally, even when proxying, so a developer's
+// scratch state never leaks into the real store's app storage.
+func (s *Server) handleRESTFallback(w http.ResponseWriter, r *http.Request) {
+	rest := r.PathValue("rest")
+
+	// Local routes take precedence over the proxy. /storage is owned by the
+	// storage feature and must stay local; guard it here so it is never
+	// forwarded even before a dedicated /storage route exists.
+	if isStoragePath(rest) {
+		s.writeNotImplemented(w, r, rest, false)
+		return
+	}
+
+	if !s.cfg.ProxyEnabled() {
+		s.writeNotImplemented(w, r, rest, true)
+		return
+	}
+
+	s.proxyRequest(w, r, rest)
+}
+
+// isStoragePath reports whether the endpoint (the path after the store ID) is
+// the storage resource or a sub-resource of it.
+func isStoragePath(rest string) bool {
+	return rest == "storage" || strings.HasPrefix(rest, "storage/")
+}
+
+// writeNotImplemented returns 501 naming the actual endpoint. When proxyable is
+// true it also states the remedy (run with --proxy-store/--proxy-token); for
+// storage — which is deliberately never proxied — it does not, since proxying
+// storage would write dev scratch state into the real store.
+func (s *Server) writeNotImplemented(w http.ResponseWriter, r *http.Request, rest string, proxyable bool) {
+	endpoint := r.Method + " " + apiPrefix + "{storeId}/" + rest
+	msg := "mock: " + endpoint + " is not implemented by ecwid-mock."
+	if proxyable {
+		msg += " Run with --proxy-store and --proxy-token to forward unimplemented endpoints to the real Ecwid API."
+	} else {
+		msg += " It is served locally and is never proxied."
+	}
+	writeJSONError(w, http.StatusNotImplemented, msg)
+}
+
+// proxyRequest forwards r to the configured real store, rewriting the store ID
+// and swapping in the proxy token, and passes the upstream response through.
+func (s *Server) proxyRequest(w http.ResponseWriter, r *http.Request, rest string) {
+	// Read-only gate: proxied writes mutate the real store and fire real
+	// webhooks from it, so block them unless explicitly opted in.
+	if s.cfg.ProxyReadonly && !isReadMethod(r.Method) {
+		s.log.Warn("proxy blocked mutation",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"target_store", s.cfg.ProxyStore,
+		)
+		writeJSONError(w, http.StatusForbidden,
+			"mock: "+r.Method+" "+apiPrefix+"{storeId}/"+rest+
+				" is blocked because --proxy-readonly is on (default). A proxied write mutates the real store "+
+				s.cfg.ProxyStore+" and fires real webhooks from it. Re-run with --proxy-readonly=false to allow proxied mutations.")
+		return
+	}
+
+	// Every proxied request is logged at warn so forwarding is never silent.
+	// Only method + path are logged — never the proxy token.
+	s.log.Warn("proxy forwarding",
+		"method", r.Method,
+		"path", r.URL.Path,
+		"target_store", s.cfg.ProxyStore,
+	)
+
+	targetURL := s.upstreamBase + apiPrefix + s.cfg.ProxyStore + "/" + rest
+	if r.URL.RawQuery != "" {
+		targetURL += "?" + r.URL.RawQuery
+	}
+
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "mock: could not build proxy request: "+err.Error())
+		return
+	}
+	copyProxyRequestHeaders(outReq.Header, r.Header)
+	// Preserve the declared body length so the upstream sees a real
+	// Content-Length instead of chunked transfer. NewRequestWithContext cannot
+	// infer it from an opaque request body.
+	outReq.ContentLength = r.ContentLength
+	// Swap the mock's fake access_token for the real proxy token.
+	outReq.Header.Set("Authorization", "Bearer "+s.cfg.ProxyToken)
+
+	resp, err := s.proxyClient.Do(outReq)
+	if err != nil {
+		// Timeout, connection refused, DNS failure, etc. — surface a sane error,
+		// never a panic. The error string is the transport's and carries no token.
+		s.log.Warn("proxy upstream error", "method", r.Method, "path", r.URL.Path, "error", err)
+		writeJSONError(w, http.StatusBadGateway, "mock: proxy request to the real Ecwid API failed: "+err.Error())
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	copyProxyResponseHeaders(w.Header(), resp.Header)
+	w.WriteHeader(resp.StatusCode)
+	// Stream the body straight through — io.Copy does not buffer the whole body,
+	// so there is no memory concern and no reason to cap (which would silently
+	// corrupt a large legitimate response). A copy error (client gone, upstream
+	// truncated) is not actionable once the status is written.
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// isReadMethod reports whether m is a non-mutating HTTP method safe to proxy
+// under --proxy-readonly.
+func isReadMethod(m string) bool {
+	return m == http.MethodGet || m == http.MethodHead
+}
+
+// copyProxyRequestHeaders copies client request headers to the upstream request,
+// dropping hop-by-hop headers and Authorization (which the caller resets to the
+// proxy token) so the mock's fake token is never forwarded.
+func copyProxyRequestHeaders(dst, src http.Header) {
+	for k, vv := range src {
+		if _, hop := hopByHopHeaders[http.CanonicalHeaderKey(k)]; hop {
+			continue
+		}
+		if http.CanonicalHeaderKey(k) == "Authorization" {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// copyProxyResponseHeaders copies upstream response headers back to the client,
+// dropping hop-by-hop headers.
+func copyProxyResponseHeaders(dst, src http.Header) {
+	for k, vv := range src {
+		if _, hop := hopByHopHeaders[http.CanonicalHeaderKey(k)]; hop {
+			continue
+		}
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// writeJSONError writes a JSON body of {"errorMessage": msg} with the given
+// status, matching Ecwid's error shape.
+func writeJSONError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"errorMessage": msg})
+}

--- a/mock/internal/server/proxy.go
+++ b/mock/internal/server/proxy.go
@@ -36,6 +36,17 @@ var hopByHopHeaders = map[string]struct{}{
 	"Upgrade":             {},
 }
 
+// newProxyTransport clones the default transport and disables automatic
+// compression. Otherwise net/http would add Accept-Encoding: gzip and
+// transparently decode gzip responses, rewriting Content-Encoding/Content-Length
+// and breaking the intended byte-for-byte passthrough; with it off, whatever the
+// upstream returns (gzipped or not) is forwarded unchanged.
+func newProxyTransport() http.RoundTripper {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DisableCompression = true
+	return t
+}
+
 // handleRESTFallback backstops every /api/v3/{storeId}/... route the mock does
 // not simulate locally. With proxying configured it forwards to the real store
 // (subject to the read-only gate); otherwise it returns an informative 501.
@@ -151,28 +162,45 @@ func isReadMethod(m string) bool {
 	return m == http.MethodGet || m == http.MethodHead
 }
 
-// copyProxyRequestHeaders copies client request headers to the upstream request,
-// dropping hop-by-hop headers and Authorization (which the caller resets to the
-// proxy token) so the mock's fake token is never forwarded.
-func copyProxyRequestHeaders(dst, src http.Header) {
-	for k, vv := range src {
-		if _, hop := hopByHopHeaders[http.CanonicalHeaderKey(k)]; hop {
-			continue
-		}
-		if http.CanonicalHeaderKey(k) == "Authorization" {
-			continue
-		}
-		for _, v := range vv {
-			dst.Add(k, v)
+// hopByHopSet returns the headers that must not be forwarded across a hop: the
+// fixed connection-scoped set plus any headers named in src's own Connection
+// header (RFC 7230 §6.1). Names are canonicalized for lookup.
+func hopByHopSet(src http.Header) map[string]struct{} {
+	drop := make(map[string]struct{}, len(hopByHopHeaders))
+	for k := range hopByHopHeaders {
+		drop[k] = struct{}{}
+	}
+	for _, v := range src.Values("Connection") {
+		for tok := range strings.SplitSeq(v, ",") {
+			if tok = strings.TrimSpace(tok); tok != "" {
+				drop[http.CanonicalHeaderKey(tok)] = struct{}{}
+			}
 		}
 	}
+	return drop
+}
+
+// copyProxyRequestHeaders copies client request headers to the upstream request,
+// dropping hop-by-hop headers (including those named by Connection) and
+// Authorization (which the caller resets to the proxy token) so the mock's fake
+// token is never forwarded.
+func copyProxyRequestHeaders(dst, src http.Header) {
+	drop := hopByHopSet(src)
+	drop["Authorization"] = struct{}{}
+	copyHeaders(dst, src, drop)
 }
 
 // copyProxyResponseHeaders copies upstream response headers back to the client,
-// dropping hop-by-hop headers.
+// dropping hop-by-hop headers (including those named by Connection).
 func copyProxyResponseHeaders(dst, src http.Header) {
+	copyHeaders(dst, src, hopByHopSet(src))
+}
+
+// copyHeaders copies every header from src to dst except those whose
+// canonicalized name is in drop.
+func copyHeaders(dst, src http.Header, drop map[string]struct{}) {
 	for k, vv := range src {
-		if _, hop := hopByHopHeaders[http.CanonicalHeaderKey(k)]; hop {
+		if _, skip := drop[http.CanonicalHeaderKey(k)]; skip {
 			continue
 		}
 		for _, v := range vv {

--- a/mock/internal/server/proxy_test.go
+++ b/mock/internal/server/proxy_test.go
@@ -1,0 +1,251 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+// proxyServer builds a Server whose proxy target is upstream (an httptest URL,
+// never the real API) and whose logs are captured in logBuf.
+func proxyServer(cfg config.Config, upstream string, logBuf io.Writer) *Server {
+	log := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	srv := New(cfg, log)
+	srv.upstreamBase = upstream
+	return srv
+}
+
+func serve(srv *Server, req *http.Request) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeErrorMessage(t *testing.T, body *bytes.Buffer) string {
+	t.Helper()
+	var parsed struct {
+		ErrorMessage string `json:"errorMessage"`
+	}
+	if err := json.NewDecoder(body).Decode(&parsed); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	return parsed.ErrorMessage
+}
+
+func TestFallback_NotImplemented_NamesEndpointAndRemedy(t *testing.T) {
+	srv := proxyServer(config.Config{StoreID: "1003"}, defaultUpstreamBase, io.Discard)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v3/1003/products", http.NoBody)
+	rec := serve(srv, req)
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotImplemented)
+	}
+	msg := decodeErrorMessage(t, rec.Body)
+	if !strings.Contains(msg, "GET /api/v3/{storeId}/products") {
+		t.Errorf("message does not name the endpoint: %q", msg)
+	}
+	if !strings.Contains(msg, "--proxy-store") || !strings.Contains(msg, "--proxy-token") {
+		t.Errorf("message does not state the proxy remedy: %q", msg)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+}
+
+func TestFallback_Proxy_ForwardsRewritingStoreAndToken(t *testing.T) {
+	var gotPath, gotQuery, gotAuth, gotMethod string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("X-Upstream", "yes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"items":[]}`)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: true}
+	srv := proxyServer(cfg, upstream.URL, io.Discard)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v3/1003/products?limit=10", http.NoBody)
+	req.Header.Set("Authorization", "Bearer mock-access-token")
+	rec := serve(srv, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("upstream method = %q, want GET", gotMethod)
+	}
+	if gotPath != "/api/v3/42/products" {
+		t.Errorf("upstream path = %q, want store ID rewritten to /api/v3/42/products", gotPath)
+	}
+	if gotQuery != "limit=10" {
+		t.Errorf("upstream query = %q, want limit=10", gotQuery)
+	}
+	if gotAuth != "Bearer real-token" {
+		t.Errorf("upstream Authorization = %q, want the proxy token swapped in", gotAuth)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, `"items"`) {
+		t.Errorf("response body not passed through: %q", body)
+	}
+	if rec.Header().Get("X-Upstream") != "yes" {
+		t.Error("upstream response header not passed through")
+	}
+}
+
+func TestFallback_Proxy_PassesLargeBodyThroughUntruncated(t *testing.T) {
+	// A body larger than a naive buffer/cap would truncate; assert it arrives
+	// whole so response passthrough never silently corrupts big payloads.
+	const size = 2 << 20 // 2 MiB
+	payload := bytes.Repeat([]byte("x"), size)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: true}
+	srv := proxyServer(cfg, upstream.URL, io.Discard)
+
+	rec := serve(srv, httptest.NewRequest(http.MethodGet, "/api/v3/1003/products", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.Len(); got != size {
+		t.Errorf("response body length = %d, want %d (must not be truncated)", got, size)
+	}
+}
+
+func TestFallback_ReadonlyDefault_BlocksMutations(t *testing.T) {
+	var upstreamHits int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: true}
+	srv := proxyServer(cfg, upstream.URL, io.Discard)
+
+	// GET proxies through.
+	getRec := serve(srv, httptest.NewRequest(http.MethodGet, "/api/v3/1003/products", http.NoBody))
+	if getRec.Code != http.StatusOK {
+		t.Errorf("GET status = %d, want 200 (proxied)", getRec.Code)
+	}
+
+	// POST is blocked with 403 and never reaches the upstream.
+	postRec := serve(srv, httptest.NewRequest(http.MethodPost, "/api/v3/1003/products", strings.NewReader(`{}`)))
+	if postRec.Code != http.StatusForbidden {
+		t.Fatalf("POST status = %d, want 403 under --proxy-readonly", postRec.Code)
+	}
+	msg := decodeErrorMessage(t, postRec.Body)
+	if !strings.Contains(msg, "--proxy-readonly=false") {
+		t.Errorf("403 message does not name the override flag: %q", msg)
+	}
+	if upstreamHits != 1 {
+		t.Errorf("upstream hits = %d, want 1 (only the GET); the blocked POST must not reach upstream", upstreamHits)
+	}
+}
+
+func TestFallback_ReadonlyDisabled_ProxiesMutations(t *testing.T) {
+	var gotMethod, gotBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: false}
+	srv := proxyServer(cfg, upstream.URL, io.Discard)
+
+	rec := serve(srv, httptest.NewRequest(http.MethodPost, "/api/v3/1003/products", strings.NewReader(`{"name":"x"}`)))
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("POST status = %d, want 201 (proxied with --proxy-readonly=false)", rec.Code)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("upstream method = %q, want POST", gotMethod)
+	}
+	if gotBody != `{"name":"x"}` {
+		t.Errorf("upstream body = %q, want request body forwarded", gotBody)
+	}
+}
+
+func TestFallback_StorageServedLocallyEvenWhenProxying(t *testing.T) {
+	var upstreamHits int
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: true}
+	srv := proxyServer(cfg, upstream.URL, io.Discard)
+
+	for _, path := range []string{"/api/v3/1003/storage", "/api/v3/1003/storage/my-key"} {
+		rec := serve(srv, httptest.NewRequest(http.MethodGet, path, http.NoBody))
+		// /storage is served by the local storage handler, which rejects a
+		// missing bearer token with 401 — proving the request was handled
+		// locally rather than proxied (a proxied miss would be 501).
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("%s status = %d, want 401 served locally", path, rec.Code)
+		}
+		msg := decodeErrorMessage(t, rec.Body)
+		if strings.Contains(msg, "--proxy-store") {
+			t.Errorf("%s: storage response must not suggest proxying: %q", path, msg)
+		}
+	}
+	if upstreamHits != 0 {
+		t.Errorf("upstream hits = %d, want 0 — /storage must never be proxied", upstreamHits)
+	}
+}
+
+func TestFallback_ProxyTokenNeverLogged(t *testing.T) {
+	const token = "super-secret-proxy-token-value"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	var logBuf bytes.Buffer
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: token, ProxyReadonly: false}
+	srv := proxyServer(cfg, upstream.URL, &logBuf)
+	// Exercise the log paths: a forwarded read, a forwarded write, and a blocked
+	// write (with readonly toggled on) all log at warn.
+	serve(srv, httptest.NewRequest(http.MethodGet, "/api/v3/1003/products", http.NoBody))
+	serve(srv, httptest.NewRequest(http.MethodPost, "/api/v3/1003/products", strings.NewReader(`{}`)))
+	srv.cfg.ProxyReadonly = true
+	serve(srv, httptest.NewRequest(http.MethodDelete, "/api/v3/1003/products/1", http.NoBody))
+
+	if strings.Contains(logBuf.String(), token) {
+		t.Errorf("proxy token leaked into logs:\n%s", logBuf.String())
+	}
+}
+
+func TestFallback_UpstreamError_NoPanic(t *testing.T) {
+	// Point the proxy at a closed listener so Do() fails immediately.
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	closedURL := upstream.URL
+	upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: true}
+	srv := proxyServer(cfg, closedURL, io.Discard)
+
+	rec := serve(srv, httptest.NewRequest(http.MethodGet, "/api/v3/1003/products", http.NoBody))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 on upstream failure", rec.Code)
+	}
+	msg := decodeErrorMessage(t, rec.Body)
+	if !strings.Contains(msg, "failed") {
+		t.Errorf("502 message = %q, want a sane upstream-failure message", msg)
+	}
+}

--- a/mock/internal/server/proxy_test.go
+++ b/mock/internal/server/proxy_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -228,6 +229,73 @@ func TestFallback_ProxyTokenNeverLogged(t *testing.T) {
 
 	if strings.Contains(logBuf.String(), token) {
 		t.Errorf("proxy token leaked into logs:\n%s", logBuf.String())
+	}
+}
+
+func TestFallback_Proxy_DropsConnectionNamedHopByHopHeaders(t *testing.T) {
+	var gotUpstream http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUpstream = r.Header.Clone()
+		// Name a hop-by-hop header on the response side too.
+		w.Header().Set("Connection", "X-Resp-Hop")
+		w.Header().Set("X-Resp-Hop", "secret")
+		w.Header().Set("X-Resp-Keep", "kept")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: true}
+	srv := proxyServer(cfg, upstream.URL, io.Discard)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v3/1003/products", http.NoBody)
+	req.Header.Set("Connection", "X-Req-Hop")
+	req.Header.Set("X-Req-Hop", "should-be-dropped")
+	req.Header.Set("X-Req-Keep", "kept")
+	rec := serve(srv, req)
+
+	if v := gotUpstream.Get("X-Req-Hop"); v != "" {
+		t.Errorf("Connection-named request header forwarded upstream: X-Req-Hop = %q, want dropped", v)
+	}
+	if v := gotUpstream.Get("X-Req-Keep"); v != "kept" {
+		t.Errorf("ordinary request header X-Req-Keep = %q, want forwarded", v)
+	}
+	if v := rec.Header().Get("X-Resp-Hop"); v != "" {
+		t.Errorf("Connection-named response header returned to client: X-Resp-Hop = %q, want dropped", v)
+	}
+	if v := rec.Header().Get("X-Resp-Keep"); v != "kept" {
+		t.Errorf("ordinary response header X-Resp-Keep = %q, want forwarded", v)
+	}
+}
+
+func TestFallback_Proxy_PassesGzipBodyThroughUndecoded(t *testing.T) {
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	if _, err := gz.Write([]byte(`{"items":[1,2,3]}`)); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	gzBytes := raw.Bytes()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(gzBytes)
+	}))
+	defer upstream.Close()
+
+	cfg := config.Config{StoreID: "1003", ProxyStore: "42", ProxyToken: "real-token", ProxyReadonly: true}
+	srv := proxyServer(cfg, upstream.URL, io.Discard)
+
+	rec := serve(srv, httptest.NewRequest(http.MethodGet, "/api/v3/1003/products", http.NoBody))
+
+	if ce := rec.Header().Get("Content-Encoding"); ce != "gzip" {
+		t.Errorf("Content-Encoding = %q, want gzip preserved (no transparent decompression)", ce)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), gzBytes) {
+		t.Errorf("body was not passed through as raw gzip bytes; got %d bytes, want %d", rec.Body.Len(), len(gzBytes))
 	}
 }
 

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -84,7 +84,7 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 			URL:          cfg.WebhookURL,
 		}),
 		upstreamBase: defaultUpstreamBase,
-		proxyClient:  &http.Client{Timeout: proxyTimeout},
+		proxyClient:  &http.Client{Timeout: proxyTimeout, Transport: newProxyTransport()},
 	}
 
 	s.routes()

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -52,6 +52,15 @@ type Server struct {
 	http    *http.Server
 	store   *appStorage
 	trigger *webhook.Trigger
+
+	// upstreamBase is the scheme+host proxied requests are forwarded to. It
+	// defaults to defaultUpstreamBase and is overridden by tests to point at an
+	// httptest server instead of the real Ecwid API.
+	upstreamBase string
+	// proxyClient forwards proxied requests. It is a plain http.Client (not the
+	// ecwid internal/api transport, which is JSON-oriented and cannot pass an
+	// opaque response through) with a bounded timeout.
+	proxyClient *http.Client
 }
 
 // New builds a Server with all routes registered. The provided logger is used
@@ -74,6 +83,8 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 			StoreID:      parseStoreID(cfg.StoreID, log),
 			URL:          cfg.WebhookURL,
 		}),
+		upstreamBase: defaultUpstreamBase,
+		proxyClient:  &http.Client{Timeout: proxyTimeout},
 	}
 
 	s.routes()
@@ -109,6 +120,14 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("PUT /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
 	s.mux.HandleFunc("POST /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
 	s.mux.HandleFunc("DELETE /api/v3/{storeId}/storage/{key}", s.handleStorageDelete)
+
+	// Simulated Ecwid REST namespace. This catch-all backstops every REST route
+	// the mock does not implement locally: it proxies to a real store when
+	// configured, otherwise returns an informative 501. Locally-implemented
+	// routes (e.g. /storage above) register more specific patterns that
+	// ServeMux prefers over this one; the handler also guards /storage directly
+	// so it is never proxied.
+	s.mux.HandleFunc("/api/v3/{storeId}/{rest...}", s.handleRESTFallback)
 
 	// Control plane: the webhook trigger API and its UI panel.
 	webhook.NewHandler(s.trigger).Routes(s.mux)


### PR DESCRIPTION
Handles REST endpoints the mock doesn't simulate: an informative `501` by default, or forwarding to a real Ecwid store when explicitly configured.

Closes #70. Depends on #66 (mock scaffold) — merged.

## What it does

- **Default (offline):** unimplemented `/api/v3/{storeId}/…` routes return `501` naming the actual endpoint **and** the remedy flags, e.g.
  `mock: GET /api/v3/{storeId}/products is not implemented by ecwid-mock. Run with --proxy-store and --proxy-token to forward unimplemented endpoints to the real Ecwid API.`
- **With `--proxy-store` + `--proxy-token`:** forwards to `https://app.ecwid.com/api/v3/{proxyStore}/…`, rewriting the store ID in the path and swapping the `Authorization` bearer for the proxy token; passes status, body, and headers back through (hop-by-hop headers stripped both directions).
- **Startup banner** prints a prominent `⚠ PROXY ENABLED` block naming the target store and read-only state when proxying is on; the proxy token is only ever shown redacted.
- **`/storage` is always served locally**, even when proxying — enforced in the fallback handler *and* by ServeMux route specificity — so dev scratch state never writes into the real store's app storage. Tested explicitly.

## ⚠️ Please confirm: `--proxy-readonly` defaults to **TRUE**

A proxied write mutates a **real** store and fires **real** webhooks from it (Ecwid fires webhooks regardless of source), which can collide confusingly with the mock's own triggered events. So by default only `GET`/`HEAD` proxy; `POST`/`PUT`/`DELETE` return `403` naming the `--proxy-readonly=false` override. Blocked mutations and every forwarded request are logged at `warn` (method + path only) so proxying is never silent.

This is the deliberately conservative "can't wreck your store" default. **Flagging it so you can veto** if it feels too restrictive.

## Transport decision

Uses a plain `http.Client` with a bounded timeout, **not** the `ecwid/internal/api` transport: that transport is JSON-oriented (decodes into `v any`) and unsuitable for an opaque passthrough, and its retry `RoundTripper` is unexported. Reusing it would mean widening `internal/api`'s exported surface, which `AGENTS.md`'s CRUCIAL RULE forbids — so I didn't.

## Tests (all against an `httptest` upstream, never the real API)

- Unimplemented endpoint → `501` with the endpoint named + remedy
- Proxy forwards to the right URL, store ID rewritten, token swapped, response passed through
- `--proxy-readonly` (default) → `GET` proxies, `POST` → `403`; blocked write never reaches upstream
- `--proxy-readonly=false` → `POST` proxies with body forwarded
- `/storage` served locally even with proxying on (upstream never hit)
- Proxy token never appears in logs (forwarded read, forwarded write, blocked write exercised)
- Upstream error → `502`, no panic
- Config: read-only defaults true, flag/env resolution, store/token must be set together, banner redacts token

`task mock:lint` / `task mock:test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
