### PR TITLE
ci(release): add the mock module to the release chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,14 @@
 name: release
 
-# Releases the two Go modules in this repo in dependency order:
+# Releases the three Go modules in this repo in dependency order:
 #   1. tag + release the `config` module (config/<version>)
 #   2. pin ecwid -> config@<version> and drop the local replace on a release
 #      commit (tagged but NOT pushed to a branch, so main keeps the dev replace)
 #   3. tag + release the `ecwid` SDK (ecwid/<version>)
+#   4. pin mock -> config@<version> AND ecwid@<version> and drop both local
+#      replaces on a release commit (tagged but NOT pushed), then tag + release
+#      the `mock` tool (mock/<version>). ecwid/<version> is pushed in step 3,
+#      so mock's pin resolves it.
 #
 # Changelogs are generated per module from conventional-commit history between
 # the previous and new module tag via requarks/changelog-action.
@@ -39,7 +43,7 @@ jobs:
             echo "::error::'${VERSION}' is not a valid semver tag (expected vX.Y.Z)"
             exit 1
           fi
-          for mod in config ecwid; do
+          for mod in config ecwid mock; do
             if git rev-parse -q --verify "refs/tags/${mod}/${VERSION}" >/dev/null; then
               echo "::error::tag ${mod}/${VERSION} already exists"
               exit 1
@@ -58,6 +62,7 @@ jobs:
         run: |
           echo "config=$(git tag -l 'config/v*' --sort=-version:refname | head -n1)" >> "$GITHUB_OUTPUT"
           echo "ecwid=$(git tag -l 'ecwid/v*' --sort=-version:refname | head -n1)" >> "$GITHUB_OUTPUT"
+          echo "mock=$(git tag -l 'mock/v*' --sort=-version:refname | head -n1)" >> "$GITHUB_OUTPUT"
 
       - name: Tag config module
         run: |
@@ -120,3 +125,48 @@ jobs:
             Requires `config ${{ env.VERSION }}`.
 
             ${{ steps.cl_ecwid.outputs.changes }}
+
+      - name: Pin config + ecwid dependencies and tag mock tool
+        env:
+          GOWORK: "off"
+          GOFLAGS: "-mod=mod"
+          GOPROXY: direct
+          GOSUMDB: "off"
+        run: |
+          cd mock
+          # mock depends on both config and ecwid, so drop both dev replaces and
+          # pin both to VERSION. ecwid/${VERSION} was tagged and pushed above, so
+          # `go mod tidy` (GOPROXY=direct) can resolve it from git.
+          go mod edit -dropreplace=github.com/matthiasbruns/ecwid-go/config
+          go mod edit -dropreplace=github.com/matthiasbruns/ecwid-go/ecwid
+          go mod edit -require="github.com/matthiasbruns/ecwid-go/config@${VERSION}"
+          go mod edit -require="github.com/matthiasbruns/ecwid-go/ecwid@${VERSION}"
+          go mod tidy
+          go build ./...
+          cd ..
+          # Release commit lives only under the mock/<version> tag; main keeps
+          # its local replaces for workspace development.
+          git add mock/go.mod mock/go.sum
+          git commit -m "chore(release): mock ${VERSION} (pin config + ecwid ${VERSION})"
+          git tag "mock/${VERSION}"
+          git push origin "mock/${VERSION}"
+
+      - name: Generate mock changelog
+        id: cl_mock
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          fromTag: mock/${{ env.VERSION }}
+          toTag: ${{ steps.prev.outputs.mock }}
+          writeToFile: false
+          excludeTypes: build,ci,chore,docs,other,style
+
+      - name: Release mock module
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: mock/${{ env.VERSION }}
+          name: mock ${{ env.VERSION }}
+          body: |
+            Requires `ecwid ${{ env.VERSION }}`.
+
+            ${{ steps.cl_mock.outputs.changes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,12 @@ jobs:
           git tag "mock/${VERSION}"
           git push origin "mock/${VERSION}"
 
+      # changelog-action needs a non-empty toTag for the range; skip it on the
+      # module's first-ever release (no previous mock tag) and fall back to a
+      # plain "Initial release." body below.
       - name: Generate mock changelog
         id: cl_mock
+        if: steps.prev.outputs.mock != ''
         uses: requarks/changelog-action@v1
         with:
           token: ${{ github.token }}
@@ -169,4 +173,4 @@ jobs:
           body: |
             Requires `ecwid ${{ env.VERSION }}`.
 
-            ${{ steps.cl_mock.outputs.changes }}
+            ${{ steps.cl_mock.outputs.changes || 'Initial release.' }}


### PR DESCRIPTION
Extends `.github/workflows/release.yml` to tag and release the `mock` module, adding a third link to the chain: **config → ecwid → mock**. Users can now `go install github.com/matthiasbruns/ecwid-go/mock@<version>`.

Closes #72

## Changes
- **Header comment** updated: "two Go modules" → "three Go modules", documenting the mock step and the ordering guarantee (ecwid's tag is pushed in step 3, so mock's pin resolves it).
- **Validation**: `mock` added to the tag-collision pre-flight loop (`for mod in config ecwid mock`).
- **Previous tag**: `mock=$(git tag -l 'mock/v*' ...)` added to *Determine previous module tags*.
- **Pin + tag**: new *Pin config + ecwid dependencies and tag mock tool* step. `mock` depends on **both** `config` and `ecwid`, so it drops **two** replaces and pins **two** requires (`config@${VERSION}`, `ecwid@${VERSION}`), then commits-but-doesn't-push and tags `mock/${VERSION}` — mirroring the ecwid step exactly (same `GOWORK/GOFLAGS/GOPROXY=direct/GOSUMDB` env). `main` keeps its dev `replace` directives.
- **Changelog + release**: mirrors the `cl_ecwid` / *Release ecwid module* steps; release body notes `Requires ecwid ${VERSION}`.

## First-release fix (found by the prerelease run)
Mirroring the ecwid changelog step verbatim **failed** on the real prerelease: `requarks/changelog-action` requires a non-empty `toTag`, but mock's *first* release has no previous `mock/v*` tag, so `steps.prev.outputs.mock` is empty → `Must provide either input tag OR (fromTag and toTag)`. The config/ecwid steps only pass because those modules already have prior tags. Fix: guard the changelog step with `if: steps.prev.outputs.mock != ''` and fall back to an `Initial release.` body via `${{ steps.cl_mock.outputs.changes || 'Initial release.' }}`. (config/ecwid have the same latent first-release behavior but are already past it — left unchanged to keep this PR scoped.)

## Ordering hazard — traced & verified
mock's release commit pins `ecwid@${VERSION}`. That tag is created **and pushed** in the earlier *Pin config dependency and tag ecwid SDK* step, before mock's `go mod tidy` runs. With `GOPROXY=direct` + `GOSUMDB=off`, tidy resolves `config@${VERSION}` and `ecwid@${VERSION}` straight from the freshly-pushed git tags. No proxy lag path (direct fetch, not the module proxy) — same handling the ecwid step already uses.

## Verified with real prerelease runs
Ran the actual workflow via `workflow_dispatch` on this branch (twice; all test tags/releases deleted afterward — repo is clean):

1. `v0.0.0-test.1` — surfaced the changelog bug above. The core chain (tag config → pin+tag ecwid → **pin config+ecwid & tag mock**) went green.
2. `v0.0.0-test.2` (after the fix) — **entire workflow green**; *Generate mock changelog* correctly skipped, *Release mock module* published with body `Requires ecwid v0.0.0-test.2` / `Initial release.`.

For both, in a **clean environment** (empty `GOMODCACHE`, `GOPROXY=direct`):
```
go install github.com/matthiasbruns/ecwid-go/mock@v0.0.0-test.2   # exit 0
ecwid-mock --help                                                  # runs
```
resolving the pinned `config@v0.0.0-test.2` and `ecwid@v0.0.0-test.2`. Confirmed `main`/branch `mock/go.mod` retains both dev `replace` directives (release commit is tag-only).

## CI (`ci.yml`) — no change needed (confirmed, not assumed)
`mock:` is already wired into the root `Taskfile.yml` `lint`/`test` aggregates (#76), so `ci.yml`'s lint and test jobs pick it up. `mock:test` runs `go test ./... -race`, which **compiles the mock `main` package**, so build breaks are caught in CI's test job — no need to add mock to the CLI-specific `build` job.

## mock/go.mod stability
`mock/go.mod` deps are settled (config, ecwid, cobra) — not in flux. mock is the second cobra consumer (with cli); `go.sum` growth is expected, no action.