### PR TITLE
feat(mock): admin shell with iframe payload injection

### DIFF
--- a/mock/internal/config/config.go
+++ b/mock/internal/config/config.go
@@ -134,6 +134,12 @@ func (c *Config) Validate() error {
 		errs = append(errs, "--app-url is required (env: ECWID_MOCK_APP_URL)")
 	} else if u, err := url.Parse(c.AppURL); err != nil || u.Scheme == "" || u.Host == "" {
 		errs = append(errs, fmt.Sprintf("--app-url %q is not a valid absolute URL", c.AppURL))
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		// The app is loaded in a browser iframe and validated via the
+		// postMessage event.origin, both of which only make sense over http(s).
+		// Reject any other scheme at startup rather than failing obscurely at
+		// render time.
+		errs = append(errs, fmt.Sprintf("--app-url %q must use http or https, got scheme %q", c.AppURL, u.Scheme))
 	}
 
 	if len(c.ClientSecret) < MinClientSecretLen {

--- a/mock/internal/config/config_test.go
+++ b/mock/internal/config/config_test.go
@@ -179,6 +179,11 @@ func TestValidate(t *testing.T) {
 			wantErr: "not a valid absolute URL",
 		},
 		{
+			name:    "non-http(s) app-url scheme",
+			cfg:     Config{AppURL: "ftp://localhost:3000", ClientSecret: validSecret, AuthMode: AuthModeDefault, Port: 8080},
+			wantErr: "must use http or https",
+		},
+		{
 			name:    "short secret",
 			cfg:     Config{AppURL: "http://localhost:3000", ClientSecret: "tooshort", AuthMode: AuthModeDefault, Port: 8080},
 			wantErr: "at least 16 bytes",

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -98,6 +98,10 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /_mock/health", handleHealth)
 
+	// The admin shell lives at the site root only; unknown paths fall through to
+	// ServeMux's 404 rather than being swallowed by a catch-all.
+	s.mux.HandleFunc("GET /{$}", s.handleShell)
+
 	// Simulated Ecwid REST: the app-storage endpoints the JS SDK actually calls
 	// over HTTP (getAppStorage/setAppStorage and the public-config variants).
 	s.mux.HandleFunc("GET /api/v3/{storeId}/storage", s.handleStorageList)

--- a/mock/internal/server/shell.go
+++ b/mock/internal/server/shell.go
@@ -1,0 +1,337 @@
+package server
+
+import (
+	"crypto/rand"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/appauth"
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+// SDK / payload defaults for the shell. These are developer-facing conveniences,
+// not part of any published contract.
+const (
+	// defaultLang is the store language placed in the payload when the shell is
+	// loaded without an explicit lang override.
+	defaultLang = "en"
+
+	// defaultViewMode is the render mode Ecwid uses for settings pages. POPUP is
+	// currently disabled by Ecwid and INLINE is rare, so PAGE is the sensible
+	// default.
+	defaultViewMode = "PAGE"
+
+	// sdkURL is the real Ecwid native-app JS SDK. The docs and the sample app
+	// both pin 1.3.0; 1.3.1 exists on the CDN but is undocumented. The developer
+	// includes this script in their own app — the shell only surfaces it for
+	// reference.
+	sdkURL = "https://djqizrxa6f10j.cloudfront.net/ecwid-sdk/js/1.3.0/ecwid-app.js"
+)
+
+//go:embed templates/shell.html
+var shellFS embed.FS
+
+// shellTmpl is parsed once at startup. A parse failure is a programming error in
+// the embedded template, so panic via template.Must rather than deferring it to
+// the first request.
+var shellTmpl = template.Must(template.ParseFS(shellFS, "templates/shell.html"))
+
+// payloadView is the decoded payload as shown in the UI, with both tokens
+// redacted. The raw tokens never reach the template — only this view does.
+type payloadView struct {
+	StoreID     int64
+	Lang        string
+	AccessToken string // redacted
+	PublicToken string // redacted
+	ViewMode    string
+	AppState    string
+	Domain      string
+}
+
+// shellView is the full template model for one render of the admin shell.
+type shellView struct {
+	AppURL    string
+	AppOrigin string
+	ClientID  string
+	AuthMode  string
+	Enhanced  bool
+
+	// IframeURL is the fully-built src for the app iframe, carrying the payload
+	// in the fragment (default mode), the query (enhanced mode), or as a
+	// devpayload query param (fixture hook). It is template.URL because it is
+	// server-built from config and must not be filtered by html/template.
+	IframeURL template.URL
+
+	// Payload is the decoded, token-redacted payload for display.
+	Payload payloadView
+
+	// RawKind labels the raw payload transport ("hex fragment" or "encrypted
+	// query blob"). RawPayload is the copy-to-clipboard value; it is the same
+	// bytes injected into the iframe, so it is offered via a copy affordance
+	// rather than printed prominently.
+	RawKind    string
+	RawPayload string
+
+	// CacheKiller is the enhanced-mode cache-busting query value, shown for
+	// reference. Empty in default mode.
+	CacheKiller string
+
+	// Control values reflected back into the form inputs.
+	StoreID  string
+	Lang     string
+	AppState string
+	ViewMode string
+
+	// SdkURL is the reference SDK script URL.
+	SdkURL string
+
+	// ConfigJS is the JSON config consumed by the page's postMessage listener:
+	// the app origin to validate against and the client_id namespace to match.
+	ConfigJS template.JS
+}
+
+// handleShell serves GET / — the admin shell that iframes the developer's app
+// with a correctly-built payload for the configured auth mode.
+//
+// Query overrides let the developer re-render without restarting the server:
+// store_id, lang, app_state, view_mode. The devpayload fixture hook (a hex
+// payload) overrides all of them and drives the iframe via a ?devpayload= query
+// param instead of the fragment, so tests can assert on a known payload without
+// touching the URL hash.
+func (s *Server) handleShell(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	view, err := s.buildShellView(q)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := shellTmpl.ExecuteTemplate(w, "shell.html", view); err != nil {
+		// Headers/partial body may already be flushed; there is nothing useful to
+		// send the client, so just record it.
+		s.log.Error("render admin shell", "error", err)
+	}
+}
+
+// buildShellView assembles the template model from config plus query overrides.
+// It returns an error only for client-correctable input (a non-numeric store_id
+// or an undecodable devpayload); everything else falls back to config defaults.
+func (s *Server) buildShellView(q url.Values) (shellView, error) {
+	appOrigin, err := originOf(s.cfg.AppURL)
+	if err != nil {
+		return shellView{}, fmt.Errorf("app URL %q has no origin: %w", s.cfg.AppURL, err)
+	}
+
+	var (
+		payload     *appauth.Payload
+		iframeURL   string
+		rawKind     string
+		rawPayload  string
+		cacheKiller string
+	)
+
+	if dev := q.Get("devpayload"); dev != "" {
+		// Fixture hook: decode the supplied hex payload and drive the iframe via a
+		// ?devpayload= query param, bypassing the fragment entirely.
+		payload, err = appauth.DecodeHex(dev)
+		if err != nil {
+			return shellView{}, fmt.Errorf("invalid devpayload: %w", err)
+		}
+		iframeURL, err = withQueryParam(s.cfg.AppURL, "devpayload", dev)
+		if err != nil {
+			return shellView{}, err
+		}
+		rawKind = "hex fragment (via devpayload)"
+		rawPayload = dev
+	} else {
+		payload, err = s.payloadFromQuery(q)
+		if err != nil {
+			return shellView{}, err
+		}
+		iframeURL, rawKind, rawPayload, cacheKiller, err = s.buildIframeURL(payload)
+		if err != nil {
+			return shellView{}, err
+		}
+	}
+
+	cfgJSON, err := json.Marshal(map[string]string{
+		"appOrigin": appOrigin,
+		"clientId":  s.cfg.ClientID,
+	})
+	if err != nil {
+		return shellView{}, fmt.Errorf("marshal shell config: %w", err)
+	}
+
+	return shellView{
+		AppURL:      s.cfg.AppURL,
+		AppOrigin:   appOrigin,
+		ClientID:    s.cfg.ClientID,
+		AuthMode:    s.cfg.AuthMode,
+		Enhanced:    s.cfg.AuthMode == config.AuthModeEnhanced,
+		IframeURL:   template.URL(iframeURL), //nolint:gosec // server-built from operator config, not user input
+		Payload:     redactedView(payload),
+		RawKind:     rawKind,
+		RawPayload:  rawPayload,
+		CacheKiller: cacheKiller,
+		StoreID:     strconv.FormatInt(payload.StoreID, 10),
+		Lang:        payload.Lang,
+		AppState:    payload.AppState,
+		ViewMode:    payload.ViewMode,
+		SdkURL:      sdkURL,
+		ConfigJS:    template.JS(cfgJSON), //nolint:gosec // JSON-encoded, HTML-escaped by encoding/json
+	}, nil
+}
+
+// payloadFromQuery builds the payload from config defaults, applying the
+// store_id / lang / app_state / view_mode query overrides. The tokens are
+// deterministic mock values so the simulated REST API (#5) can recognize them.
+func (s *Server) payloadFromQuery(q url.Values) (*appauth.Payload, error) {
+	storeIDStr := firstNonEmpty(q.Get("store_id"), s.cfg.StoreID)
+	storeID, err := strconv.ParseInt(storeIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid store_id %q: must be an integer", storeIDStr)
+	}
+
+	return &appauth.Payload{
+		StoreID:     storeID,
+		Lang:        firstNonEmpty(q.Get("lang"), defaultLang),
+		AccessToken: mockAccessToken(storeIDStr),
+		PublicToken: mockPublicToken(storeIDStr),
+		ViewMode:    firstNonEmpty(q.Get("view_mode"), defaultViewMode),
+		AppState:    q.Get("app_state"),
+		// Domain is left empty: forcing the SDK's API host at the app breaks apps
+		// that do not expect it. The shell documents the getEcwidSdkApiDomain()
+		// and domain-field overrides instead of imposing them.
+	}, nil
+}
+
+// buildIframeURL encodes the payload for the configured auth mode and returns
+// the iframe src, a human label for the raw transport, the raw payload string
+// (for the copy affordance), and the enhanced-mode cache-killer ("" in default
+// mode).
+func (s *Server) buildIframeURL(p *appauth.Payload) (iframeURL, rawKind, rawPayload, cacheKiller string, err error) {
+	switch s.cfg.AuthMode {
+	case config.AuthModeEnhanced:
+		blob, err := appauth.Encrypt(p, s.cfg.ClientSecret)
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("encrypt payload: %w", err)
+		}
+		cacheKiller, err = randomCacheKiller()
+		if err != nil {
+			return "", "", "", "", err
+		}
+		u, err := url.Parse(s.cfg.AppURL)
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("parse app URL: %w", err)
+		}
+		query := u.Query()
+		query.Set("payload", blob)
+		if p.AppState != "" {
+			query.Set("app_state", p.AppState)
+		}
+		query.Set("cache-killer", cacheKiller)
+		u.RawQuery = query.Encode()
+		return u.String(), "encrypted query blob (?payload=)", blob, cacheKiller, nil
+
+	default: // config.AuthModeDefault
+		hexPayload, err := appauth.EncodeHex(p)
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("hex-encode payload: %w", err)
+		}
+		u, err := url.Parse(s.cfg.AppURL)
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("parse app URL: %w", err)
+		}
+		u.Fragment = hexPayload
+		return u.String(), "hex fragment (#)", hexPayload, "", nil
+	}
+}
+
+// redactedView copies the payload into its display form with both tokens masked.
+func redactedView(p *appauth.Payload) payloadView {
+	return payloadView{
+		StoreID:     p.StoreID,
+		Lang:        p.Lang,
+		AccessToken: redactToken(p.AccessToken),
+		PublicToken: redactToken(p.PublicToken),
+		ViewMode:    p.ViewMode,
+		AppState:    p.AppState,
+		Domain:      p.Domain,
+	}
+}
+
+// withQueryParam returns rawURL with key=value set on its query string.
+func withQueryParam(rawURL, key, value string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse app URL: %w", err)
+	}
+	q := u.Query()
+	q.Set(key, value)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// originOf returns the scheme://host origin used to validate postMessage events.
+func originOf(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("not an absolute URL")
+	}
+	return u.Scheme + "://" + u.Host, nil
+}
+
+// randomCacheKiller returns a short random hex string used to defeat caching of
+// the enhanced-mode iframe request, mirroring Ecwid's cache-killer param.
+func randomCacheKiller() (string, error) {
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate cache-killer: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// mockAccessToken derives a deterministic stand-in access_token for a store, so
+// the payload carries a plausible token the simulated REST API can recognize.
+func mockAccessToken(storeID string) string {
+	return "secret_mock_" + storeID + "_access"
+}
+
+// mockPublicToken derives a deterministic stand-in public_token for a store.
+func mockPublicToken(storeID string) string {
+	return "public_mock_" + storeID + "_public"
+}
+
+// firstNonEmpty returns a if it is non-empty, else b.
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+
+// redactToken masks all but the last four characters, matching the codebase's
+// all-but-last-4 policy. An empty token stays empty so an absent optional token
+// (e.g. public_token) is not mistaken for a hidden one.
+func redactToken(t string) string {
+	switch {
+	case t == "":
+		return ""
+	case len(t) <= 4:
+		return "****"
+	default:
+		return strings.Repeat("*", len(t)-4) + t[len(t)-4:]
+	}
+}

--- a/mock/internal/server/shell.go
+++ b/mock/internal/server/shell.go
@@ -44,7 +44,10 @@ var shellFS embed.FS
 var shellTmpl = template.Must(template.ParseFS(shellFS, "templates/shell.html"))
 
 // payloadView is the decoded payload as shown in the UI, with both tokens
-// redacted. The raw tokens never reach the template — only this view does.
+// redacted, so the human-readable table never prints raw token values. (The
+// separate shellView.RawPayload copy affordance does carry the full payload —
+// in default mode that is hex-encoded plaintext including the tokens — because
+// it is the exact bytes injected into the iframe.)
 type payloadView struct {
 	StoreID     int64
 	Lang        string
@@ -200,12 +203,16 @@ func (s *Server) payloadFromQuery(q url.Values) (*appauth.Payload, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid store_id %q: must be an integer", storeIDStr)
 	}
+	// Derive tokens from the canonical parsed ID (not the raw string) so that a
+	// non-canonical input like store_id=042 cannot leave StoreID=42 while the
+	// tokens encode "042".
+	canonicalStoreID := strconv.FormatInt(storeID, 10)
 
 	return &appauth.Payload{
 		StoreID:     storeID,
 		Lang:        firstNonEmpty(q.Get("lang"), defaultLang),
-		AccessToken: mockAccessToken(storeIDStr),
-		PublicToken: mockPublicToken(storeIDStr),
+		AccessToken: mockAccessToken(canonicalStoreID),
+		PublicToken: mockPublicToken(canonicalStoreID),
 		ViewMode:    firstNonEmpty(q.Get("view_mode"), defaultViewMode),
 		AppState:    q.Get("app_state"),
 		// Domain is left empty: forcing the SDK's API host at the app breaks apps

--- a/mock/internal/server/shell_test.go
+++ b/mock/internal/server/shell_test.go
@@ -150,6 +150,30 @@ func TestShell_QueryOverrides(t *testing.T) {
 	}
 }
 
+func TestShell_NonCanonicalStoreID(t *testing.T) {
+	// store_id=042 parses to 42; the derived tokens must encode the canonical
+	// "42", not the raw "042", so the payload stays internally consistent.
+	rec := getShell(t, defaultShellConfig(), "store_id=042")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	src := extractIframeSrc(t, rec.Body.String())
+	u, err := url.Parse(src)
+	if err != nil {
+		t.Fatalf("parse iframe src: %v", err)
+	}
+	got, err := appauth.DecodeHex(u.Fragment)
+	if err != nil {
+		t.Fatalf("DecodeHex(fragment) error = %v", err)
+	}
+	if got.StoreID != 42 {
+		t.Errorf("StoreID = %d, want 42", got.StoreID)
+	}
+	if got.AccessToken != mockAccessToken("42") {
+		t.Errorf("access_token = %q, want token derived from canonical id 42", got.AccessToken)
+	}
+}
+
 func TestShell_Devpayload(t *testing.T) {
 	fixture := &appauth.Payload{
 		StoreID:     7777,

--- a/mock/internal/server/shell_test.go
+++ b/mock/internal/server/shell_test.go
@@ -1,0 +1,248 @@
+package server
+
+import (
+	"html"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/appauth"
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+// testSecret is at least 16 bytes so appauth can derive an AES-128 key.
+const testSecret = "shell_test_client_secret_0123456789"
+
+func defaultShellConfig() config.Config {
+	return config.Config{
+		AppURL:       "http://localhost:3000",
+		ClientID:     "mock-app",
+		ClientSecret: testSecret,
+		StoreID:      "1003",
+		AuthMode:     config.AuthModeDefault,
+		Port:         0,
+	}
+}
+
+func getShell(t *testing.T, cfg config.Config, rawQuery string) *httptest.ResponseRecorder {
+	t.Helper()
+	srv := New(cfg, discardLogger())
+	target := "/"
+	if rawQuery != "" {
+		target += "?" + rawQuery
+	}
+	req := httptest.NewRequest(http.MethodGet, target, http.NoBody)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestShell_DefaultMode(t *testing.T) {
+	rec := getShell(t, defaultShellConfig(), "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "auth: default") {
+		t.Error("body missing default auth-mode badge")
+	}
+	// Default mode injects the payload in the fragment. The iframe src must carry
+	// a '#<hex>' fragment on the app URL.
+	if !strings.Contains(body, `src="http://localhost:3000#`) {
+		t.Errorf("iframe src missing hex fragment; body:\n%s", body)
+	}
+	// The enhanced-mode warning must NOT appear in default mode.
+	if strings.Contains(body, "getPayload() will be undefined") {
+		t.Error("default mode should not show the enhanced getPayload warning")
+	}
+	// The postMessage config must expose the app origin for validation.
+	if !strings.Contains(body, `"appOrigin":"http://localhost:3000"`) {
+		t.Error("shell-config missing appOrigin for postMessage validation")
+	}
+}
+
+func TestShell_RedactsAccessToken(t *testing.T) {
+	rec := getShell(t, defaultShellConfig(), "")
+	body := rec.Body.String()
+
+	// The plaintext mock access_token must never be rendered in the decoded view.
+	plain := mockAccessToken("1003")
+	if strings.Contains(body, plain) {
+		t.Errorf("rendered UI leaked plaintext access_token %q", plain)
+	}
+	// The redacted form (all but last 4 masked) must be present instead.
+	if !strings.Contains(body, redactToken(plain)) {
+		t.Errorf("rendered UI missing redacted access_token %q", redactToken(plain))
+	}
+	// The decoded store_id must still be visible so the table clearly rendered.
+	if !strings.Contains(body, ">1003<") {
+		t.Error("decoded payload table missing store_id 1003")
+	}
+}
+
+func TestShell_EnhancedMode(t *testing.T) {
+	cfg := defaultShellConfig()
+	cfg.AuthMode = config.AuthModeEnhanced
+
+	rec := getShell(t, cfg, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "auth: enhanced") {
+		t.Error("body missing enhanced auth-mode badge")
+	}
+	if !strings.Contains(body, "getPayload() will be undefined") {
+		t.Error("enhanced mode must surface the getPayload()-undefined warning")
+	}
+	// The iframe src must carry ?payload= and a cache-killer.
+	src := extractIframeSrc(t, body)
+	u, err := url.Parse(src)
+	if err != nil {
+		t.Fatalf("parse iframe src %q: %v", src, err)
+	}
+	q := u.Query()
+	blob := q.Get("payload")
+	if blob == "" {
+		t.Fatalf("iframe src missing payload param: %s", src)
+	}
+	if q.Get("cache-killer") == "" {
+		t.Errorf("iframe src missing cache-killer: %s", src)
+	}
+	// The encrypted blob must round-trip through appauth.Decrypt back to the
+	// expected store context.
+	got, err := appauth.Decrypt(blob, testSecret)
+	if err != nil {
+		t.Fatalf("Decrypt(payload) error = %v", err)
+	}
+	if got.StoreID != 1003 {
+		t.Errorf("decrypted store_id = %d, want 1003", got.StoreID)
+	}
+	if got.AccessToken != mockAccessToken("1003") {
+		t.Errorf("decrypted access_token = %q, want %q", got.AccessToken, mockAccessToken("1003"))
+	}
+}
+
+func TestShell_QueryOverrides(t *testing.T) {
+	rec := getShell(t, defaultShellConfig(), "store_id=42&lang=de&view_mode=INLINE&app_state=orderId%3A7")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	src := extractIframeSrc(t, rec.Body.String())
+	u, err := url.Parse(src)
+	if err != nil {
+		t.Fatalf("parse iframe src: %v", err)
+	}
+	got, err := appauth.DecodeHex(strings.TrimPrefix(u.Fragment, "#"))
+	if err != nil {
+		t.Fatalf("DecodeHex(fragment) error = %v", err)
+	}
+	if got.StoreID != 42 || got.Lang != "de" || got.ViewMode != "INLINE" || got.AppState != "orderId:7" {
+		t.Errorf("overrides not applied: %+v", got)
+	}
+}
+
+func TestShell_Devpayload(t *testing.T) {
+	fixture := &appauth.Payload{
+		StoreID:     7777,
+		Lang:        "fr",
+		AccessToken: "secret_fixture_token",
+		ViewMode:    "PAGE",
+	}
+	hexPayload, err := appauth.EncodeHex(fixture)
+	if err != nil {
+		t.Fatalf("EncodeHex: %v", err)
+	}
+
+	rec := getShell(t, defaultShellConfig(), "devpayload="+hexPayload)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	// The decoded view must reflect the fixture, not the config defaults.
+	if !strings.Contains(body, ">7777<") {
+		t.Error("devpayload store_id 7777 not reflected in decoded view")
+	}
+	// The iframe must drive the app via ?devpayload=, not the fragment.
+	src := extractIframeSrc(t, body)
+	u, err := url.Parse(src)
+	if err != nil {
+		t.Fatalf("parse iframe src: %v", err)
+	}
+	if u.Query().Get("devpayload") != hexPayload {
+		t.Errorf("iframe src missing devpayload query param: %s", src)
+	}
+	if u.Fragment != "" {
+		t.Errorf("devpayload mode should not use a fragment, got %q", u.Fragment)
+	}
+	// The fixture's plaintext token must still be redacted in the display.
+	if strings.Contains(body, "secret_fixture_token") {
+		t.Error("devpayload view leaked plaintext access_token")
+	}
+}
+
+func TestShell_InvalidStoreID(t *testing.T) {
+	rec := getShell(t, defaultShellConfig(), "store_id=not-a-number")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for non-numeric store_id", rec.Code)
+	}
+}
+
+func TestShell_InvalidDevpayload(t *testing.T) {
+	rec := getShell(t, defaultShellConfig(), "devpayload=zzzz-not-hex")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for undecodable devpayload", rec.Code)
+	}
+}
+
+func TestShell_UnknownPathNotFound(t *testing.T) {
+	// The shell is registered at the root only ("GET /{$}"); an unknown path must
+	// 404 rather than be swallowed by a catch-all.
+	srv := New(defaultShellConfig(), discardLogger())
+	req := httptest.NewRequest(http.MethodGet, "/does-not-exist", http.NoBody)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for unknown path (shell must not be a catch-all)", rec.Code)
+	}
+}
+
+func TestRedactToken(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"abcd", "****"},
+		{"ab", "****"},
+		{"secret_token", "********oken"},
+	}
+	for _, tt := range tests {
+		if got := redactToken(tt.in); got != tt.want {
+			t.Errorf("redactToken(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// extractIframeSrc pulls the app-frame src attribute out of the rendered HTML.
+func extractIframeSrc(t *testing.T, body string) string {
+	t.Helper()
+	const marker = `id="app-frame" src="`
+	_, rest, found := strings.Cut(body, marker)
+	if !found {
+		t.Fatalf("iframe app-frame not found in body")
+	}
+	end := strings.IndexByte(rest, '"')
+	if end < 0 {
+		t.Fatalf("iframe src attribute not terminated")
+	}
+	// html/template HTML-escapes attribute values (e.g. '&' -> '&amp;'); a real
+	// browser decodes these before requesting the URL, so undo it for parsing.
+	return html.UnescapeString(rest[:end])
+}

--- a/mock/internal/server/templates/shell.html
+++ b/mock/internal/server/templates/shell.html
@@ -1,0 +1,315 @@
+{{define "shell.html" -}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ecwid-mock — admin shell</title>
+  <style>
+    :root {
+      --bg: #f4f6f8;
+      --panel: #ffffff;
+      --border: #dfe3e8;
+      --ink: #1a1f27;
+      --muted: #6b7280;
+      --accent: #2a7de1;
+      --warn-bg: #fff8e1;
+      --warn-border: #f0c000;
+      --warn-ink: #6b5300;
+      --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+    }
+    header.topbar {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      background: #1e2a38;
+      color: #fff;
+      padding: 10px 16px;
+    }
+    header.topbar .brand { font-weight: 600; letter-spacing: .2px; }
+    header.topbar .tag {
+      font-size: 12px;
+      color: #b9c4d0;
+      border: 1px solid #38485a;
+      border-radius: 4px;
+      padding: 1px 6px;
+    }
+    .badge {
+      display: inline-block;
+      font-size: 12px;
+      font-weight: 600;
+      border-radius: 999px;
+      padding: 2px 10px;
+    }
+    .badge.default { background: #e3f0ff; color: #1c5fb0; }
+    .badge.enhanced { background: #efe3ff; color: #6a2fb0; }
+    .layout {
+      display: grid;
+      grid-template-columns: 380px 1fr;
+      gap: 16px;
+      padding: 16px;
+      align-items: start;
+    }
+    @media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px 16px;
+      margin-bottom: 16px;
+    }
+    .panel h2 {
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      color: var(--muted);
+      margin: 0 0 10px;
+    }
+    .muted { color: var(--muted); }
+    label { display: block; font-size: 12px; color: var(--muted); margin: 8px 0 2px; }
+    input[type=text], select {
+      width: 100%;
+      padding: 6px 8px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font: inherit;
+    }
+    button {
+      font: inherit;
+      cursor: pointer;
+      border: 1px solid var(--accent);
+      background: var(--accent);
+      color: #fff;
+      border-radius: 6px;
+      padding: 7px 14px;
+    }
+    button.secondary { background: #fff; color: var(--accent); }
+    .row { display: flex; gap: 8px; margin-top: 12px; }
+    table.kv { width: 100%; border-collapse: collapse; }
+    table.kv th, table.kv td {
+      text-align: left;
+      padding: 5px 4px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+      font-size: 13px;
+    }
+    table.kv th { color: var(--muted); font-weight: 500; width: 40%; }
+    code, .mono { font-family: var(--mono); font-size: 12px; word-break: break-all; }
+    .warn {
+      background: var(--warn-bg);
+      border: 1px solid var(--warn-border);
+      color: var(--warn-ink);
+      border-radius: 8px;
+      padding: 10px 12px;
+      margin-bottom: 16px;
+      font-size: 13px;
+    }
+    .warn strong { display: block; margin-bottom: 4px; }
+    .frame-wrap { position: relative; background: #fff; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+    .frame-head {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 8px 12px; border-bottom: 1px solid var(--border); font-size: 12px; color: var(--muted);
+    }
+    iframe#app-frame { width: 100%; height: 640px; border: 0; display: block; background: #fff; }
+    #loading {
+      position: absolute; inset: 41px 0 0 0;
+      display: flex; align-items: center; justify-content: center;
+      background: rgba(255,255,255,.9); color: var(--muted); font-size: 13px;
+    }
+    #loading .spinner {
+      width: 18px; height: 18px; margin-right: 10px;
+      border: 2px solid var(--border); border-top-color: var(--accent);
+      border-radius: 50%; animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    #event-log { list-style: none; margin: 0; padding: 0; max-height: 260px; overflow: auto; }
+    #event-log li { padding: 6px 4px; border-bottom: 1px solid var(--border); font-family: var(--mono); font-size: 12px; }
+    #event-log li .m { color: var(--accent); font-weight: 600; }
+    #event-log li .t { color: var(--muted); }
+    #event-log .empty { color: var(--muted); font-family: inherit; font-style: italic; }
+    details.help { margin-top: 8px; }
+    details.help summary { cursor: pointer; color: var(--accent); font-size: 13px; }
+    details.help p, details.help li { font-size: 13px; }
+    .copywrap { display: flex; gap: 8px; align-items: center; margin-top: 6px; }
+    .copywrap .preview { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); }
+  </style>
+</head>
+<body>
+  <header class="topbar">
+    <span class="brand">ecwid-mock</span>
+    <span class="tag">admin shell</span>
+    {{if .Enhanced}}<span class="badge enhanced">auth: enhanced</span>{{else}}<span class="badge default">auth: default</span>{{end}}
+  </header>
+
+  <div class="layout">
+    <aside>
+      <section class="panel">
+        <h2>Payload controls</h2>
+        <form method="get" action="/">
+          <label for="store_id">store_id</label>
+          <input type="text" id="store_id" name="store_id" value="{{.StoreID}}">
+          <label for="lang">lang</label>
+          <input type="text" id="lang" name="lang" value="{{.Lang}}">
+          <label for="view_mode">view_mode</label>
+          <select id="view_mode" name="view_mode">
+            {{$vm := .ViewMode}}
+            <option value="PAGE"{{if eq $vm "PAGE"}} selected{{end}}>PAGE</option>
+            <option value="POPUP"{{if eq $vm "POPUP"}} selected{{end}}>POPUP</option>
+            <option value="INLINE"{{if eq $vm "INLINE"}} selected{{end}}>INLINE</option>
+          </select>
+          <label for="app_state">app_state</label>
+          <input type="text" id="app_state" name="app_state" value="{{.AppState}}" placeholder="deep-link state, e.g. orderId:12">
+          <div class="row">
+            <button type="submit">Reload iframe</button>
+            <button type="button" class="secondary" id="copy-raw" data-raw="{{.RawPayload}}">Copy raw payload</button>
+          </div>
+          <div class="copywrap"><span class="preview mono">{{.RawKind}}</span></div>
+        </form>
+      </section>
+
+      {{if .Enhanced}}
+      <div class="warn">
+        <strong>Enhanced mode: EcwidApp.getPayload() will be undefined.</strong>
+        The SDK only hex-decodes the fragment (or a <code>payload</code>/<code>devpayload</code>
+        query param) — it never decrypts. Your app must read <code>?payload=</code> server-side and
+        decrypt it (e.g. <code>appauth.Decrypt</code>), then inject the result into its own HTML,
+        exactly as Ecwid's docs do with <code>var payload = &lt;?php echo $result; ?&gt;;</code>.
+      </div>
+      {{end}}
+
+      <section class="panel">
+        <h2>Decoded payload</h2>
+        <table class="kv">
+          <tr><th>store_id</th><td class="mono">{{.Payload.StoreID}}</td></tr>
+          <tr><th>lang</th><td class="mono">{{.Payload.Lang}}</td></tr>
+          <tr><th>access_token</th><td class="mono">{{.Payload.AccessToken}} <span class="muted">(redacted)</span></td></tr>
+          <tr><th>public_token</th><td class="mono">{{if .Payload.PublicToken}}{{.Payload.PublicToken}} <span class="muted">(redacted)</span>{{else}}<span class="muted">—</span>{{end}}</td></tr>
+          <tr><th>view_mode</th><td class="mono">{{.Payload.ViewMode}}</td></tr>
+          <tr><th>app_state</th><td class="mono">{{if .Payload.AppState}}{{.Payload.AppState}}{{else}}<span class="muted">—</span>{{end}}</td></tr>
+          <tr><th>domain</th><td class="mono">{{if .Payload.Domain}}{{.Payload.Domain}}{{else}}<span class="muted">—</span>{{end}}</td></tr>
+        </table>
+        {{if .CacheKiller}}<p class="muted" style="margin:8px 0 0">cache-killer: <span class="mono">{{.CacheKiller}}</span></p>{{end}}
+        <details class="help">
+          <summary>Point the SDK's storage calls at the mock</summary>
+          <p class="muted">The SDK's <code>getAppStorage</code>/<code>setAppStorage</code> calls hit
+          <code>app.ecwid.com</code> by default. To redirect them here, the app must opt in via
+          either hook:</p>
+          <ul class="muted">
+            <li>define <code>window.getEcwidSdkApiDomain()</code> to return this host (cleanest), or</li>
+            <li>rely on the undocumented <code>domain</code> payload field (SDK 1.3.1+).</li>
+          </ul>
+          <p class="muted">Reference SDK: <span class="mono">{{.SdkURL}}</span></p>
+        </details>
+      </section>
+
+      {{block "webhookPanel" .}}
+      <section class="panel" id="webhook-panel">
+        <h2>Webhooks</h2>
+        <p class="muted">Webhook trigger panel — added in #6.</p>
+      </section>
+      {{end}}
+    </aside>
+
+    <main>
+      <div class="frame-wrap">
+        <div class="frame-head">
+          <span>app iframe — <span class="mono">{{.AppURL}}</span></span>
+          <span class="mono">origin: {{.AppOrigin}}</span>
+        </div>
+        <div id="loading"><span class="spinner"></span> waiting for EcwidApp.ready()…</div>
+        <iframe id="app-frame" src="{{.IframeURL}}" title="embedded app"></iframe>
+      </div>
+
+      <section class="panel" style="margin-top:16px">
+        <h2>postMessage event log</h2>
+        <ul id="event-log"><li class="empty">No messages yet. child→parent SDK calls (ready, setSize, openPage, closeAppPopup, upgradePlan) appear here.</li></ul>
+      </section>
+    </main>
+  </div>
+
+  <script type="application/json" id="shell-config">{{.ConfigJS}}</script>
+  <script>
+    (function () {
+      "use strict";
+      var cfg = JSON.parse(document.getElementById("shell-config").textContent);
+      var iframe = document.getElementById("app-frame");
+      var loading = document.getElementById("loading");
+      var logEl = document.getElementById("event-log");
+      var empty = logEl.querySelector(".empty");
+
+      function pad(n) { return n < 10 ? "0" + n : "" + n; }
+      function stamp(d) { return pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds()); }
+
+      function addLog(method, data) {
+        if (empty) { empty.remove(); empty = null; }
+        var li = document.createElement("li");
+        var m = document.createElement("span");
+        m.className = "m"; m.textContent = method;
+        var t = document.createElement("span");
+        t.className = "t"; t.textContent = "  " + stamp(new Date());
+        li.appendChild(m);
+        if (data !== undefined && data !== null && !(typeof data === "object" && Object.keys(data).length === 0)) {
+          var d = document.createElement("span");
+          d.textContent = "  " + JSON.stringify(data);
+          li.appendChild(d);
+        }
+        li.appendChild(t);
+        logEl.insertBefore(li, logEl.firstChild);
+      }
+
+      window.addEventListener("message", function (e) {
+        // The SDK posts child→parent with target origin "*", so validate the
+        // sender origin against the configured app URL before trusting anything.
+        if (e.origin !== cfg.appOrigin) { return; }
+        var msg;
+        try { msg = JSON.parse(e.data); } catch (err) { return; }
+        if (!msg || String(msg.ecwidAppNs) !== String(cfg.clientId)) { return; }
+
+        switch (msg.method) {
+          case "ready":
+            loading.style.display = "none";
+            addLog("ready", msg.data);
+            break;
+          case "setSize":
+            if (msg.data && typeof msg.data.height === "number") {
+              iframe.style.height = msg.data.height + "px";
+            }
+            addLog("setSize", msg.data);
+            break;
+          case "openPage":
+          case "closeAppPopup":
+          case "upgradePlan":
+          default:
+            addLog(msg.method, msg.data);
+            break;
+        }
+      });
+
+      var copyBtn = document.getElementById("copy-raw");
+      if (copyBtn) {
+        copyBtn.addEventListener("click", function () {
+          var raw = copyBtn.getAttribute("data-raw") || "";
+          var done = function () {
+            var prev = copyBtn.textContent;
+            copyBtn.textContent = "Copied!";
+            setTimeout(function () { copyBtn.textContent = prev; }, 1200);
+          };
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(raw).then(done, function () { window.prompt("Copy raw payload:", raw); });
+          } else {
+            window.prompt("Copy raw payload:", raw);
+          }
+        });
+      }
+    })();
+  </script>
+</body>
+</html>
+{{- end}}


### PR DESCRIPTION
Implements #67 — the mock admin shell: a page that iframes the developer's app exactly the way Ecwid's store admin does, injecting a correct payload in either auth mode.

## What's here

- **`internal/server/shell.go`** — `GET /{$}` handler that builds the store-context payload from config (+ query overrides) and encodes it for the configured auth mode:
  - `default` → hex-encoded plaintext JSON in the **fragment** (`#<hex>`), via `appauth.EncodeHex`.
  - `enhanced` → AES blob in the **query string** (`?payload=…&app_state=…&cache-killer=…`), via `appauth.Encrypt`, with a random cache-killer.
- **`internal/server/templates/shell.html`** — stdlib `html/template` + `go:embed`, no JS framework. Ecwid-admin-style chrome hosting the app iframe, decoded payload table, raw-payload copy affordance, SDK/domain override hints, postMessage event log, and a `{{block "webhookPanel"}}` slot reserved for #6.

## Faithful to the researched contract

- **Enhanced mode surfaces the #1 gotcha**: `EcwidApp.getPayload()` never decrypts — it hex-decodes — so in enhanced mode it returns `undefined`. The shell shows a prominent warning that the app must read `?payload=` and decrypt server-side (`appauth.Decrypt`).
- **postMessage handling** (child→parent only): the page listens for `ready` (stops the loading spinner), `setSize` (auto-resizes the iframe), and logs `openPage`/`closeAppPopup`/`upgradePlan`. Since the SDK posts with target origin `"*"`, **`event.origin` is validated against `--app-url`** and messages are matched on `ecwidAppNs === client_id`.
- **`access_token` (and `public_token`) are redacted** in the rendered decoded view.
- No UI for `getAppPublicToken` / `getInitialContext` (they don't exist in the SDK).
- **`?devpayload=<hex>` fixture hook** for driving the shell from tests without touching the hash.
- SDK-storage redirection (`window.getEcwidSdkApiDomain()` / the `domain` payload field) is documented in the UI, not imposed.

## Verification

- `task mock:lint` → 0 issues; `task mock:test` → pass (`-race`).
- Manually verified end-to-end: default mode emits a hex fragment that decodes to valid payload JSON; enhanced mode emits a `?payload=` blob that round-trips through `appauth.Decrypt` plus a `cache-killer`; unknown paths 404; invalid `store_id`/`devpayload` return 400.

Closes #67