### PR TITLE
feat(mock): webhook trigger UI and HTTP control API

### DIFF
--- a/ecwid/webhooks/handler.go
+++ b/ecwid/webhooks/handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 )
 
@@ -15,26 +16,26 @@ import (
 // unauthenticated POST cannot exhaust memory.
 const maxBodyBytes = 1 << 20 // 1 MiB
 
-// isSuccessCode reports whether Ecwid accepts status as a successful delivery.
-// Everything else, including 203, 208 and every 3xx, is a failed delivery that
-// Ecwid will retry.
-func isSuccessCode(status int) bool {
-	switch status {
-	case http.StatusOK, // 200
+// SuccessCodes lists the HTTP status codes Ecwid counts as a successful webhook
+// delivery: 200, 201, 202, 204 and 209. Every other status — including 203, 208
+// and every 3xx — is a failed delivery that Ecwid retries.
+//
+// It returns a fresh slice per call, so there is no package-level state to
+// mutate, and exists so local tooling (the mock server's delivery classifier)
+// applies exactly the set this package enforces rather than a hand-copied one.
+func SuccessCodes() []int {
+	return []int{
+		http.StatusOK,        // 200
 		http.StatusCreated,   // 201
 		http.StatusAccepted,  // 202
 		http.StatusNoContent, // 204
-		209:                  // no net/http constant; not a registered IANA code
-		return true
-	default:
-		return false
+		209,                  // no net/http constant; not a registered IANA code
 	}
 }
 
-// successCodes lists those same codes for error messages and tests. It returns a
-// fresh slice per call, so there is no package-level state to mutate.
-func successCodes() []int {
-	return []int{http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent, 209}
+// isSuccessCode reports whether Ecwid accepts status as a successful delivery.
+func isSuccessCode(status int) bool {
+	return slices.Contains(SuccessCodes(), status)
 }
 
 // Deduper records which events have been processed, so a replayed or retried
@@ -136,7 +137,7 @@ func NewHandler(clientSecret string, handle func(ctx context.Context, e Event), 
 		code = http.StatusOK
 	}
 	if !isSuccessCode(code) {
-		return nil, fmt.Errorf("webhooks: SuccessCode %d is not one Ecwid accepts (want one of %v)", code, successCodes())
+		return nil, fmt.Errorf("webhooks: SuccessCode %d is not one Ecwid accepts (want one of %v)", code, SuccessCodes())
 	}
 	if opts.MaxAge < 0 {
 		return nil, fmt.Errorf("webhooks: MaxAge must not be negative, got %s", opts.MaxAge)

--- a/ecwid/webhooks/handler_test.go
+++ b/ecwid/webhooks/handler_test.go
@@ -67,7 +67,7 @@ func newRequest(body string, signature *string) *http.Request {
 	}
 	var e Event
 	if err := json.Unmarshal([]byte(body), &e); err == nil {
-		r.Header.Set(SignatureHeader, sign(e.EventCreated, e.EventID, testSecret))
+		r.Header.Set(SignatureHeader, Sign(e.EventCreated, e.EventID, testSecret))
 	}
 	return r
 }
@@ -131,13 +131,13 @@ func TestHandler_RejectsBadSignature(t *testing.T) {
 			// *signed* fields were altered does not.
 			name:       "tampered eventId",
 			body:       strings.Replace(orderCreatedBody, `"eventId":"80aece08-40e8-4145-8764-6c2f0d38678"`, `"eventId":"00000000-0000-0000-0000-000000000000"`, 1),
-			signature:  new(sign(testEventCreated, testEventID, testSecret)),
+			signature:  new(Sign(testEventCreated, testEventID, testSecret)),
 			wantStatus: http.StatusUnauthorized,
 		},
 		{
 			name:       "signature from a different secret",
 			body:       orderCreatedBody,
-			signature:  new(sign(testEventCreated, testEventID, "some_other_secret")),
+			signature:  new(Sign(testEventCreated, testEventID, "some_other_secret")),
 			wantStatus: http.StatusUnauthorized,
 		},
 	}
@@ -325,7 +325,7 @@ func TestHandler_OnErrorNeverLeaksSecrets(t *testing.T) {
 }
 
 func TestHandler_SuccessCode(t *testing.T) {
-	for _, code := range successCodes() {
+	for _, code := range SuccessCodes() {
 		t.Run(fmt.Sprint(code), func(t *testing.T) {
 			var rec recorder
 			h := newTestHandler(t, rec.handle, &Options{SuccessCode: code})
@@ -407,7 +407,7 @@ func TestHandler_RespondsBeforeCallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest() = %v", err)
 	}
-	req.Header.Set(SignatureHeader, sign(testEventCreated, testEventID, testSecret))
+	req.Header.Set(SignatureHeader, Sign(testEventCreated, testEventID, testSecret))
 
 	// Do runs asynchronously: should the handler ever wait for the callback
 	// before responding, it and the callback would wait on each other forever,
@@ -475,7 +475,7 @@ func TestHandler_CallbackContextNotCanceled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRequest() = %v", err)
 	}
-	req.Header.Set(SignatureHeader, sign(testEventCreated, testEventID, testSecret))
+	req.Header.Set(SignatureHeader, Sign(testEventCreated, testEventID, testSecret))
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/ecwid/webhooks/verify.go
+++ b/ecwid/webhooks/verify.go
@@ -58,9 +58,18 @@ func mac(eventCreated int64, eventID, clientSecret string) []byte {
 	return h.Sum(nil)
 }
 
-// sign produces the signature Verify expects. Kept unexported: real callers only
-// ever verify, and an exported signer would invite using this package to forge
-// the very events it exists to authenticate.
-func sign(eventCreated int64, eventID, clientSecret string) string {
+// Sign produces the signature [Verify] expects: the value Ecwid would send in
+// [SignatureHeader] for the given (eventCreated, eventID) pair.
+//
+// It exists for local tooling that must emit webhooks the same package verifies —
+// the mock server's webhook trigger, and test harnesses — so signing and
+// verification share one MAC and cannot drift. It is deliberately the only
+// exported way to produce a signature: real integrations receive webhooks and
+// only ever verify.
+//
+// Signing requires the app's client_secret, so exposing it grants no capability
+// to anyone who does not already hold that secret — the secret alone is enough to
+// forge by any means. Guard the secret, never the algorithm.
+func Sign(eventCreated int64, eventID, clientSecret string) string {
 	return base64.StdEncoding.EncodeToString(mac(eventCreated, eventID, clientSecret))
 }

--- a/ecwid/webhooks/verify_test.go
+++ b/ecwid/webhooks/verify_test.go
@@ -117,10 +117,10 @@ func TestVerify_Rejects(t *testing.T) {
 // not be concatenable into the same message by different values.
 func TestVerify_SeparatorIsNotAmbiguous(t *testing.T) {
 	// "1.23" and "12.3" must sign differently.
-	a := sign(1, "23", testSecret)
-	b := sign(12, "3", testSecret)
+	a := Sign(1, "23", testSecret)
+	b := Sign(12, "3", testSecret)
 	if a == b {
-		t.Error("sign(1, \"23\") == sign(12, \"3\"), separator is being ignored")
+		t.Error("Sign(1, \"23\") == Sign(12, \"3\"), separator is being ignored")
 	}
 	if err := Verify(a, 12, "3", testSecret); err == nil {
 		t.Error("Verify() accepted a signature for a different (eventCreated, eventID) split")
@@ -129,14 +129,14 @@ func TestVerify_SeparatorIsNotAmbiguous(t *testing.T) {
 
 func TestVerify_NegativeAndZeroEventCreated(t *testing.T) {
 	for _, created := range []int64{0, -1} {
-		if err := Verify(sign(created, testEventID, testSecret), created, testEventID, testSecret); err != nil {
+		if err := Verify(Sign(created, testEventID, testSecret), created, testEventID, testSecret); err != nil {
 			t.Errorf("Verify() with eventCreated = %d = %v, want nil", created, err)
 		}
 	}
 }
 
 func TestSign_MatchesKnownGoodVector(t *testing.T) {
-	if got := sign(testEventCreated, testEventID, testSecret); got != testSignature {
-		t.Errorf("sign() = %q, want %q", got, testSignature)
+	if got := Sign(testEventCreated, testEventID, testSecret); got != testSignature {
+		t.Errorf("Sign() = %q, want %q", got, testSignature)
 	}
 }

--- a/mock/AGENTS.md
+++ b/mock/AGENTS.md
@@ -43,12 +43,37 @@ mock/
 └── internal/
     ├── config/                 # mock Config: flags > env > defaults, validation
     │   └── config.go
+    ├── webhook/                # webhook trigger: compose, sign, deliver, classify
+    │   ├── catalog.go          # the 42 event fixtures + per-family metadata
+    │   ├── trigger.go          # Trigger: compose (ecwid/webhooks), sign, POST
+    │   ├── classify.go         # Ecwid success/failure rules, with reasons
+    │   ├── http.go             # control API handlers (trigger, events)
+    │   ├── ui.go               # trigger panel handler
+    │   └── templates/panel.html
     └── server/                 # ServeMux, request logging, graceful lifecycle
         ├── server.go           # New, routes, Run (graceful shutdown)
         ├── middleware.go       # structured slog request logging
         ├── health.go           # GET /_mock/health
         └── storage.go          # app-storage REST endpoints (the JS SDK's only HTTP calls)
 ```
+
+## Webhook trigger (control plane)
+
+The mock's headline feature — Ecwid ships no webhook test tooling at all. All
+under `/_mock/` (the control-plane namespace):
+
+| Route | Purpose |
+|-------|---------|
+| `POST /_mock/webhooks/trigger` | Compose, sign, and deliver a webhook; returns the delivery result (status, latency, success/failure classification with reason, response body). **The primary surface** — CI integration tests drive this; the UI is a client of it. |
+| `GET /_mock/webhooks/events` | The 42 event types with their group, `entityId` wire type, and fixture `data`. |
+| `GET /_mock/webhooks/ui` | The developer-facing trigger panel (stdlib `html/template` + `go:embed`, no JS framework). |
+
+Events are composed with `ecwid/webhooks` (types, `Event` marshaling, `Sign`,
+`SuccessCodes`) so the mock exercises the exact code a real integration runs —
+including the `entityId` quirk (a number for order/product families, a quoted
+string for `application.*`) and the no-`data`-key families. The 24h/27-attempt
+retry schedule is deliberately **not** implemented; report the outcome and let
+the user re-fire.
 
 Everything lives under `internal/` — this module ships a binary, not a library,
 so it has **zero exported API surface** to keep as a compatibility contract.

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+	"github.com/matthiasbruns/ecwid-go/mock/internal/webhook"
 )
 
 // readHeaderTimeout bounds how long the server waits for request headers,
@@ -45,11 +46,12 @@ const shutdownTimeout = 10 * time.Second
 
 // Server wraps the HTTP server and its configuration.
 type Server struct {
-	cfg   config.Config
-	log   *slog.Logger
-	mux   *http.ServeMux
-	http  *http.Server
-	store *appStorage
+	cfg     config.Config
+	log     *slog.Logger
+	mux     *http.ServeMux
+	http    *http.Server
+	store   *appStorage
+	trigger *webhook.Trigger
 }
 
 // New builds a Server with all routes registered. The provided logger is used
@@ -67,6 +69,11 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 		log:   log,
 		mux:   mux,
 		store: newAppStorage(),
+		trigger: webhook.NewTrigger(webhook.Config{
+			ClientSecret: cfg.ClientSecret,
+			StoreID:      parseStoreID(cfg.StoreID, log),
+			URL:          cfg.WebhookURL,
+		}),
 	}
 
 	s.routes()
@@ -85,9 +92,9 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 	return s
 }
 
-// routes registers the mock's HTTP handlers. Only the control-plane health
-// check exists in this skeleton; the admin shell, simulated REST, and remaining
-// control endpoints are added by later issues.
+// routes registers the mock's HTTP handlers. The admin shell and simulated REST
+// namespaces are filled in by later issues; the control plane carries the health
+// check and the webhook trigger API and UI.
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /_mock/health", handleHealth)
 
@@ -98,6 +105,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("PUT /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
 	s.mux.HandleFunc("POST /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
 	s.mux.HandleFunc("DELETE /api/v3/{storeId}/storage/{key}", s.handleStorageDelete)
+
+	// Control plane: the webhook trigger API and its UI panel.
+	webhook.NewHandler(s.trigger).Routes(s.mux)
 }
 
 // Run starts the server and blocks until ctx is canceled (e.g. on SIGINT or
@@ -137,4 +147,16 @@ func (s *Server) Run(ctx context.Context) error {
 // Handler exposes the underlying mux for tests.
 func (s *Server) Handler() http.Handler {
 	return s.mux
+}
+
+// parseStoreID converts the configured store ID to the numeric form Ecwid puts
+// in a webhook's storeId. A non-numeric value is not fatal — the mock still runs
+// and fires webhooks — so it logs and falls back to 0 rather than failing.
+func parseStoreID(id string, log *slog.Logger) int64 {
+	n, err := strconv.ParseInt(id, 10, 64)
+	if err != nil {
+		log.Warn("store ID is not numeric; webhooks will use storeId 0", "store_id", id)
+		return 0
+	}
+	return n
 }

--- a/mock/internal/server/server_test.go
+++ b/mock/internal/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -72,6 +73,65 @@ func TestRun_GracefulShutdown(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Run did not return after context cancel")
+	}
+}
+
+func TestWebhookTrigger_EndToEnd(t *testing.T) {
+	var gotSig string
+	var gotBody []byte
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Ecwid-Webhook-Signature")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	srv := New(config.Config{
+		Port:         0,
+		StoreID:      "1003",
+		ClientSecret: "test_client_secret_1234567890",
+		WebhookURL:   backend.URL,
+	}, discardLogger())
+
+	body := `{"eventType":"order.created","signature":"valid"}`
+	req := httptest.NewRequest(http.MethodPost, "/_mock/webhooks/trigger", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body %s", rec.Code, rec.Body.String())
+	}
+	var res struct {
+		Delivered    bool   `json:"delivered"`
+		EventID      string `json:"eventId"`
+		EventCreated int64  `json:"eventCreated"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.Delivered {
+		t.Error("delivered = false, want true for a 200 endpoint")
+	}
+	if len(gotBody) == 0 {
+		t.Fatal("backend received no webhook body")
+	}
+	// The signature the mock sent must verify with the same secret, proving the
+	// mock and a real handler agree.
+	if gotSig == "" {
+		t.Error("backend received no signature header")
+	}
+}
+
+func TestWebhookUI_Reachable(t *testing.T) {
+	srv := New(config.Config{Port: 0, StoreID: "1003", ClientSecret: "test_client_secret_1234567890"}, discardLogger())
+	req := httptest.NewRequest(http.MethodGet, "/_mock/webhooks/ui", http.NoBody)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("UI status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("UI Content-Type = %q, want text/html", ct)
 	}
 }
 

--- a/mock/internal/webhook/catalog.go
+++ b/mock/internal/webhook/catalog.go
@@ -1,0 +1,167 @@
+// Package webhook builds, signs, delivers, and classifies Ecwid webhooks for the
+// mock's trigger control API and UI.
+//
+// Every event is composed with [webhooks.Event] and signed with [webhooks.Sign],
+// so the mock exercises the exact wire format, entityId typing, and signature a
+// real integration receives — running the same code users run is the whole point
+// of the tool.
+package webhook
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/webhooks"
+)
+
+// entityId wire types. Ecwid is not consistent: application.* events send a
+// quoted string while every other family sends a bare JSON number. The mock
+// reproduces that quirk so tooling built against it hits the same bug class real
+// integrations do.
+const (
+	// EntityIDNumber marks a family whose entityId is a bare JSON number.
+	EntityIDNumber = "number"
+	// EntityIDString marks a family (application.*) whose entityId is a quoted
+	// JSON string.
+	EntityIDString = "string"
+)
+
+// applicationPrefix is the event family whose entityId serializes as a string.
+const applicationPrefix = "application."
+
+// EventSpec is the fixture for one event type: the default entityId and data
+// payload used when the caller supplies neither, so the UI's Fire button works
+// with zero input.
+type EventSpec struct {
+	// Type is the event, e.g. [webhooks.EventOrderCreated].
+	Type webhooks.EventType
+	// EntityID is the default entityId in string form. It serializes as a JSON
+	// number for every family except application.*, which serializes a quoted
+	// string; see [EventSpec.EntityIDType].
+	EntityID string
+	// Data is the default data payload, or nil for the families that carry no
+	// data key at all (product.*, category.*, discount_coupon.*,
+	// application.installed/uninstalled, and the class, group, and GDPR events).
+	Data json.RawMessage
+}
+
+// Group is the event's display group: the entity prefix before the first dot,
+// e.g. "order" for order.created, "customer_group" for customer_group.updated.
+func (s EventSpec) Group() string {
+	prefix, _, _ := strings.Cut(string(s.Type), ".")
+	return prefix
+}
+
+// EntityIDType reports whether the event serializes entityId as a JSON number
+// ([EntityIDNumber]) or a quoted string ([EntityIDString]).
+func (s EventSpec) EntityIDType() string {
+	if strings.HasPrefix(string(s.Type), applicationPrefix) {
+		return EntityIDString
+	}
+	return EntityIDNumber
+}
+
+// HasData reports whether the event carries a data key.
+func (s EventSpec) HasData() bool {
+	return len(s.Data) > 0
+}
+
+// catalog is the fixture for all 42 Ecwid webhook events, ordered by family so
+// the UI dropdown groups sensibly. Data shapes follow ecwid/webhooks; families
+// documented to carry no data are left with a nil Data and emit no data key.
+var catalog = []EventSpec{
+	// Store profile. entityId is the numeric store ID.
+	{Type: webhooks.EventProfileUpdated, EntityID: "1003"},
+	{Type: webhooks.EventProfileSubscriptionStatusChanged, EntityID: "1003", Data: json.RawMessage(`{"oldSubscriptionName":"ECWID_BUSINESS","newSubscriptionName":"ECWID_UNLIMITED"}`)},
+	{Type: webhooks.EventProfilePersonalDataRemovalReq, EntityID: "1003"},
+	{Type: webhooks.EventProfilePersonalDataExportReq, EntityID: "1003"},
+
+	// Orders. entityId is the internal order ID (a number); the human-readable ID
+	// is data.orderId.
+	{Type: webhooks.EventOrderCreated, EntityID: "103878161", Data: json.RawMessage(`{"orderId":"XJ12H","newPaymentStatus":"PAID","newFulfillmentStatus":"AWAITING_PROCESSING"}`)},
+	{Type: webhooks.EventOrderUpdated, EntityID: "103878161", Data: json.RawMessage(`{"orderId":"XJ12H","oldPaymentStatus":"AWAITING_PAYMENT","newPaymentStatus":"PAID","oldFulfillmentStatus":"AWAITING_PROCESSING","newFulfillmentStatus":"PROCESSING"}`)},
+	{Type: webhooks.EventOrderDeleted, EntityID: "103878161", Data: json.RawMessage(`{"orderId":"XJ12H"}`)},
+
+	// Abandoned carts.
+	{Type: webhooks.EventUnfinishedOrderCreated, EntityID: "103878162", Data: json.RawMessage(`{"orderId":"RA1SD","cartId":"a1b2c3d4-0000-4000-8000-000000000000"}`)},
+	{Type: webhooks.EventUnfinishedOrderUpdated, EntityID: "103878162", Data: json.RawMessage(`{"orderId":"RA1SD","cartId":"a1b2c3d4-0000-4000-8000-000000000000"}`)},
+	{Type: webhooks.EventUnfinishedOrderDeleted, EntityID: "103878162", Data: json.RawMessage(`{"orderId":"RA1SD","cartId":"a1b2c3d4-0000-4000-8000-000000000000"}`)},
+
+	// Products. No data key.
+	{Type: webhooks.EventProductCreated, EntityID: "12345678"},
+	{Type: webhooks.EventProductUpdated, EntityID: "12345678"},
+	{Type: webhooks.EventProductDeleted, EntityID: "12345678"},
+
+	// Categories. No data key.
+	{Type: webhooks.EventCategoryCreated, EntityID: "8901234"},
+	{Type: webhooks.EventCategoryUpdated, EntityID: "8901234"},
+	{Type: webhooks.EventCategoryDeleted, EntityID: "8901234"},
+
+	// Product types (classes). No data key.
+	{Type: webhooks.EventProductClassCreated, EntityID: "1000001"},
+	{Type: webhooks.EventProductClassUpdated, EntityID: "1000001"},
+	{Type: webhooks.EventProductClassDeleted, EntityID: "1000001"},
+
+	// Customers.
+	{Type: webhooks.EventCustomerCreated, EntityID: "5001", Data: json.RawMessage(`{"customerEmail":"jane@example.com"}`)},
+	{Type: webhooks.EventCustomerUpdated, EntityID: "5001", Data: json.RawMessage(`{"customerEmail":"jane@example.com"}`)},
+	{Type: webhooks.EventCustomerDeleted, EntityID: "5001", Data: json.RawMessage(`{"customerEmail":"jane@example.com"}`)},
+
+	// Customer GDPR. No data key; the customer is identified by entityId.
+	{Type: webhooks.EventCustomerPersonalDataRemovalReq, EntityID: "5001"},
+	{Type: webhooks.EventCustomerPersonalDataExportReq, EntityID: "5001"},
+
+	// Customer groups. No data key.
+	{Type: webhooks.EventCustomerGroupCreated, EntityID: "10"},
+	{Type: webhooks.EventCustomerGroupUpdated, EntityID: "10"},
+	{Type: webhooks.EventCustomerGroupDeleted, EntityID: "10"},
+
+	// Discount coupons. No data key.
+	{Type: webhooks.EventDiscountCouponCreated, EntityID: "701"},
+	{Type: webhooks.EventDiscountCouponUpdated, EntityID: "701"},
+	{Type: webhooks.EventDiscountCouponDeleted, EntityID: "701"},
+
+	// Promotions (advanced discounts).
+	{Type: webhooks.EventPromotionCreated, EntityID: "301", Data: json.RawMessage(`{"version":1}`)},
+	{Type: webhooks.EventPromotionUpdated, EntityID: "301", Data: json.RawMessage(`{"version":2}`)},
+	{Type: webhooks.EventPromotionDeleted, EntityID: "301", Data: json.RawMessage(`{"version":3}`)},
+
+	// Product reviews. status is absent on review.deleted.
+	{Type: webhooks.EventReviewCreated, EntityID: "9001", Data: json.RawMessage(`{"productId":12345678,"orderId":103878161,"status":"MODERATED"}`)},
+	{Type: webhooks.EventReviewUpdated, EntityID: "9001", Data: json.RawMessage(`{"productId":12345678,"orderId":103878161,"status":"PUBLISHED"}`)},
+	{Type: webhooks.EventReviewDeleted, EntityID: "9001", Data: json.RawMessage(`{"productId":12345678,"orderId":103878161}`)},
+
+	// Order tax invoices. There is no invoice.updated event.
+	{Type: webhooks.EventInvoiceCreated, EntityID: "103878161", Data: json.RawMessage(`{"orderId":"GH781"}`)},
+	{Type: webhooks.EventInvoiceDeleted, EntityID: "103878161", Data: json.RawMessage(`{"orderId":"GH781"}`)},
+
+	// Applications. entityId is a quoted STRING, not a number. installed and
+	// uninstalled carry no data.
+	{Type: webhooks.EventApplicationInstalled, EntityID: "1003"},
+	{Type: webhooks.EventApplicationUninstalled, EntityID: "1003"},
+	{Type: webhooks.EventApplicationSubscriptionStatusChanged, EntityID: "1003", Data: json.RawMessage(`{"oldSubscriptionStatus":"TRIAL","newSubscriptionStatus":"ACTIVE"}`)},
+	{Type: webhooks.EventApplicationStorageChanged, EntityID: "1003", Data: json.RawMessage(`{"key":"config"}`)},
+}
+
+// byType indexes the catalog for O(1) lookup.
+var byType = func() map[webhooks.EventType]EventSpec {
+	m := make(map[webhooks.EventType]EventSpec, len(catalog))
+	for _, s := range catalog {
+		m[s.Type] = s
+	}
+	return m
+}()
+
+// Lookup returns the fixture for an event type, and whether it is a known event.
+func Lookup(t webhooks.EventType) (EventSpec, bool) {
+	s, ok := byType[t]
+	return s, ok
+}
+
+// Catalog returns a copy of every event fixture, ordered by family. The copy
+// keeps callers from mutating the shared fixtures.
+func Catalog() []EventSpec {
+	out := make([]EventSpec, len(catalog))
+	copy(out, catalog)
+	return out
+}

--- a/mock/internal/webhook/catalog_test.go
+++ b/mock/internal/webhook/catalog_test.go
@@ -1,0 +1,87 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/webhooks"
+)
+
+// wantEventCount is the number of Ecwid webhook events the mock fires. It is
+// asserted so an accidental add or drop in the catalog is caught.
+const wantEventCount = 42
+
+func TestCatalog_Count(t *testing.T) {
+	if got := len(Catalog()); got != wantEventCount {
+		t.Fatalf("catalog has %d events, want %d", got, wantEventCount)
+	}
+}
+
+func TestCatalog_TypesUnique(t *testing.T) {
+	seen := map[webhooks.EventType]bool{}
+	for _, s := range Catalog() {
+		if seen[s.Type] {
+			t.Errorf("duplicate event type %q", s.Type)
+		}
+		seen[s.Type] = true
+	}
+}
+
+func TestCatalog_LookupRoundTrips(t *testing.T) {
+	for _, s := range Catalog() {
+		got, ok := Lookup(s.Type)
+		if !ok {
+			t.Errorf("Lookup(%q) not found", s.Type)
+			continue
+		}
+		if got.EntityID != s.EntityID {
+			t.Errorf("Lookup(%q).EntityID = %q, want %q", s.Type, got.EntityID, s.EntityID)
+		}
+	}
+	if _, ok := Lookup("no.such.event"); ok {
+		t.Error("Lookup of an unknown event returned ok")
+	}
+}
+
+func TestCatalog_EntityIDType(t *testing.T) {
+	for _, s := range Catalog() {
+		want := EntityIDNumber
+		if strings.HasPrefix(string(s.Type), applicationPrefix) {
+			want = EntityIDString
+		}
+		if got := s.EntityIDType(); got != want {
+			t.Errorf("%q EntityIDType = %q, want %q", s.Type, got, want)
+		}
+	}
+}
+
+// The families Ecwid documents as carrying no data must have a nil fixture so
+// they are emitted with no data key at all — never "data":{}.
+func TestCatalog_NoDataFamilies(t *testing.T) {
+	noData := map[webhooks.EventType]bool{
+		webhooks.EventProductCreated: true, webhooks.EventProductUpdated: true, webhooks.EventProductDeleted: true,
+		webhooks.EventCategoryCreated: true, webhooks.EventCategoryUpdated: true, webhooks.EventCategoryDeleted: true,
+		webhooks.EventDiscountCouponCreated: true, webhooks.EventDiscountCouponUpdated: true, webhooks.EventDiscountCouponDeleted: true,
+		webhooks.EventApplicationInstalled: true, webhooks.EventApplicationUninstalled: true,
+	}
+	for _, s := range Catalog() {
+		if noData[s.Type] && s.HasData() {
+			t.Errorf("%q must carry no data, got %s", s.Type, s.Data)
+		}
+	}
+}
+
+func TestCatalog_GroupDerivation(t *testing.T) {
+	cases := map[webhooks.EventType]string{
+		webhooks.EventOrderCreated:           "order",
+		webhooks.EventCustomerGroupCreated:   "customer_group",
+		webhooks.EventApplicationInstalled:   "application",
+		webhooks.EventUnfinishedOrderCreated: "unfinished_order",
+	}
+	for et, want := range cases {
+		s, _ := Lookup(et)
+		if got := s.Group(); got != want {
+			t.Errorf("%q Group = %q, want %q", et, got, want)
+		}
+	}
+}

--- a/mock/internal/webhook/classify.go
+++ b/mock/internal/webhook/classify.go
@@ -1,0 +1,46 @@
+package webhook
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/webhooks"
+)
+
+// Classification is the verdict on a delivery's HTTP status: whether Ecwid would
+// count it as delivered, and why. The reason is the point — a developer needs to
+// know that a 208 or a 301 silently fails, not just the raw status.
+type Classification struct {
+	// Delivered reports whether Ecwid counts the status as a successful delivery.
+	Delivered bool
+	// Reason explains the verdict in words, e.g.
+	// "208 -> NOT delivered: a 2xx Ecwid does not count as success".
+	Reason string
+}
+
+// classify maps an HTTP status to Ecwid's delivery rules, using
+// [webhooks.SuccessCodes] as the single source of truth for the success set so
+// the mock can never drift from what the library enforces.
+func classify(status int) Classification {
+	codes := webhooks.SuccessCodes()
+	if slices.Contains(codes, status) {
+		return Classification{
+			Delivered: true,
+			Reason:    fmt.Sprintf("%d -> delivered: one of Ecwid's success codes %v", status, codes),
+		}
+	}
+
+	switch {
+	case status >= 300 && status < 400:
+		return Classification{Reason: fmt.Sprintf(
+			"%d -> NOT delivered: every 3xx is a failure — Ecwid does not follow redirects, so an endpoint that redirects (e.g. HTTP->HTTPS) silently never receives the webhook",
+			status)}
+	case status >= 200 && status < 300:
+		return Classification{Reason: fmt.Sprintf(
+			"%d -> NOT delivered: a 2xx that Ecwid does not count as success — only %v do (203 and 208 are the traps)",
+			status, codes)}
+	default:
+		return Classification{Reason: fmt.Sprintf(
+			"%d -> NOT delivered: only %v count as success", status, codes)}
+	}
+}

--- a/mock/internal/webhook/classify_test.go
+++ b/mock/internal/webhook/classify_test.go
@@ -1,0 +1,28 @@
+package webhook
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		status        int
+		wantDelivered bool
+	}{
+		// Ecwid's success set.
+		{200, true}, {201, true}, {202, true}, {204, true}, {209, true},
+		// 2xx traps that are NOT success.
+		{203, false}, {208, false}, {206, false},
+		// Every 3xx fails — the redirect trap.
+		{301, false}, {302, false}, {307, false},
+		// Ordinary failures.
+		{400, false}, {404, false}, {500, false}, {199, false},
+	}
+	for _, tt := range tests {
+		got := classify(tt.status)
+		if got.Delivered != tt.wantDelivered {
+			t.Errorf("classify(%d).Delivered = %t, want %t", tt.status, got.Delivered, tt.wantDelivered)
+		}
+		if got.Reason == "" {
+			t.Errorf("classify(%d).Reason is empty; the reason must always be reported", tt.status)
+		}
+	}
+}

--- a/mock/internal/webhook/http.go
+++ b/mock/internal/webhook/http.go
@@ -1,0 +1,146 @@
+package webhook
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/webhooks"
+)
+
+// Handler serves the webhook control API and UI panel. It is the client-facing
+// surface over a [Trigger]:
+//
+//	POST /_mock/webhooks/trigger   fire a webhook, return the delivery result
+//	GET  /_mock/webhooks/events    the 42 event types and their data shapes
+//	GET  /_mock/webhooks/ui        the developer-facing trigger panel
+//
+// Register the routes with [Handler.Routes].
+type Handler struct {
+	trigger *Trigger
+}
+
+// NewHandler builds a control-API handler over trigger.
+func NewHandler(trigger *Trigger) *Handler {
+	return &Handler{trigger: trigger}
+}
+
+// Routes registers the webhook control-plane and UI handlers on mux.
+func (h *Handler) Routes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /_mock/webhooks/trigger", h.handleTrigger)
+	mux.HandleFunc("GET /_mock/webhooks/events", h.handleEvents)
+	mux.HandleFunc("GET /_mock/webhooks/ui", h.handleUI)
+}
+
+// triggerRequest is the JSON body of POST /_mock/webhooks/trigger. entityId
+// accepts a JSON number or a quoted string, mirroring the wire quirk, and is
+// normalized to a string.
+type triggerRequest struct {
+	EventType string          `json:"eventType"`
+	EntityID  json.RawMessage `json:"entityId"`
+	Data      json.RawMessage `json:"data"`
+	Signature SignatureMode   `json:"signature"`
+}
+
+func (h *Handler) handleTrigger(w http.ResponseWriter, r *http.Request) {
+	var body triggerRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+	if body.EventType == "" {
+		writeError(w, http.StatusBadRequest, "eventType is required")
+		return
+	}
+
+	entityID, err := normalizeEntityID(body.EntityID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "entityId must be a JSON string or number: "+err.Error())
+		return
+	}
+
+	res, err := h.trigger.Fire(r.Context(), Request{
+		EventType: webhooks.EventType(body.EventType),
+		EntityID:  entityID,
+		Data:      body.Data,
+		Mode:      body.Signature,
+	})
+	switch {
+	case errors.Is(err, ErrNoWebhookURL):
+		writeError(w, http.StatusConflict, "no --webhook-url configured; set it to deliver webhooks")
+		return
+	case errors.Is(err, ErrUnknownEvent):
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	case err != nil:
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, res)
+}
+
+// eventInfo is one entry of GET /_mock/webhooks/events.
+type eventInfo struct {
+	EventType    string          `json:"eventType"`
+	Group        string          `json:"group"`
+	EntityIDType string          `json:"entityIdType"`
+	HasData      bool            `json:"hasData"`
+	EntityID     string          `json:"entityId"`
+	Data         json.RawMessage `json:"data,omitempty"`
+}
+
+func (h *Handler) handleEvents(w http.ResponseWriter, _ *http.Request) {
+	specs := Catalog()
+	events := make([]eventInfo, len(specs))
+	for i, s := range specs {
+		events[i] = eventInfo{
+			EventType:    string(s.Type),
+			Group:        s.Group(),
+			EntityIDType: s.EntityIDType(),
+			HasData:      s.HasData(),
+			EntityID:     s.EntityID,
+			Data:         s.Data,
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": events})
+}
+
+// normalizeEntityID reduces a raw JSON entityId to a string: "" for absent/null,
+// the string contents for a quoted string, or the digits for a number.
+func normalizeEntityID(raw json.RawMessage) (string, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return "", nil
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return "", err
+		}
+		return s, nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return "", err
+	}
+	return n.String(), nil
+}
+
+// writeJSON writes v as an indented JSON response with the given status.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	// The client may have gone away; there is nothing actionable to do on error.
+	_ = enc.Encode(v)
+}
+
+// writeError writes a JSON error envelope.
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/mock/internal/webhook/http_test.go
+++ b/mock/internal/webhook/http_test.go
@@ -1,0 +1,194 @@
+package webhook
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/webhooks"
+)
+
+// newTestServer wires a Handler over a Trigger delivering to url onto a mux.
+func newTestServer(t *testing.T, url string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	NewHandler(newTestTrigger(t, url)).Routes(mux)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestHTTP_Trigger_NumericEntityIDInRequest(t *testing.T) {
+	var gotBody []byte
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody = readBody(t, r)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	control := newTestServer(t, backend.URL)
+
+	// entityId as a bare JSON number, mirroring the issue's example.
+	body := `{"eventType":"order.updated","entityId":103878161,"data":{"orderId":"XJ12H","newPaymentStatus":"PAID"}}`
+	resp, err := http.Post(control.URL+"/_mock/webhooks/trigger", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var res Result
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.Delivered {
+		t.Errorf("delivered = false, reason %q", res.Reason)
+	}
+	if res.EntityID != "103878161" {
+		t.Errorf("entityId = %q, want 103878161", res.EntityID)
+	}
+
+	var e webhooks.Event
+	if err := json.Unmarshal(gotBody, &e); err != nil {
+		t.Fatal(err)
+	}
+	if e.EntityID != "103878161" {
+		t.Errorf("delivered entityId = %q, want 103878161", e.EntityID)
+	}
+}
+
+func TestHTTP_Trigger_NoURLReturns409(t *testing.T) {
+	control := newTestServer(t, "")
+	resp, err := http.Post(control.URL+"/_mock/webhooks/trigger", "application/json",
+		strings.NewReader(`{"eventType":"order.created"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("status = %d, want 409 when no --webhook-url", resp.StatusCode)
+	}
+}
+
+func TestHTTP_Trigger_BadRequests(t *testing.T) {
+	control := newTestServer(t, "http://127.0.0.1:0")
+	cases := map[string]string{
+		"missing eventType": `{"entityId":1}`,
+		"unknown event":     `{"eventType":"no.such.event"}`,
+		"malformed JSON":    `{`,
+		"unknown field":     `{"eventType":"order.created","nope":1}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			resp, err := http.Post(control.URL+"/_mock/webhooks/trigger", "application/json", strings.NewReader(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestHTTP_Events(t *testing.T) {
+	control := newTestServer(t, "")
+	resp, err := http.Get(control.URL + "/_mock/webhooks/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var payload struct {
+		Events []eventInfo `json:"events"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if len(payload.Events) != wantEventCount {
+		t.Fatalf("events = %d, want %d", len(payload.Events), wantEventCount)
+	}
+	for _, ev := range payload.Events {
+		if ev.EventType == "" || ev.Group == "" || ev.EntityIDType == "" {
+			t.Errorf("event %q has an empty field: %+v", ev.EventType, ev)
+		}
+	}
+}
+
+func TestHTTP_UI(t *testing.T) {
+	enabled := newTestServer(t, "http://example.test/hook")
+	body := getBody(t, enabled.URL+"/_mock/webhooks/ui")
+	if !strings.Contains(body, "Webhook Trigger") {
+		t.Error("UI missing its heading")
+	}
+	if !strings.Contains(body, "http://example.test/hook") {
+		t.Error("UI does not show the configured webhook URL")
+	}
+	if strings.Contains(body, `type="submit" disabled`) {
+		t.Error("UI Fire button disabled while a webhook URL is configured")
+	}
+
+	disabled := newTestServer(t, "")
+	body = getBody(t, disabled.URL+"/_mock/webhooks/ui")
+	if !strings.Contains(body, `type="submit" disabled`) {
+		t.Error("UI Fire button not disabled without a webhook URL")
+	}
+}
+
+func TestNormalizeEntityID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`103878161`, "103878161"},
+		{`"1003"`, "1003"},
+		{`  42 `, "42"},
+		{``, ""},
+		{`null`, ""},
+	}
+	for _, c := range cases {
+		got, err := normalizeEntityID(json.RawMessage(c.in))
+		if err != nil {
+			t.Errorf("normalizeEntityID(%q) error: %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("normalizeEntityID(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	if _, err := normalizeEntityID(json.RawMessage(`{}`)); err == nil {
+		t.Error("normalizeEntityID of an object should error")
+	}
+}
+
+func readBody(t *testing.T, r *http.Request) []byte {
+	t.Helper()
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func getBody(t *testing.T, url string) string {
+	t.Helper()
+	resp, err := http.Get(url) //nolint:noctx // test helper
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s = %d, want 200", url, resp.StatusCode)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/mock/internal/webhook/templates/panel.html
+++ b/mock/internal/webhook/templates/panel.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Webhook Trigger — ecwid-mock</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 2rem;
+    font: 15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+    max-width: 900px; margin-inline: auto;
+  }
+  h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  h2 { font-size: 1.05rem; margin: 2rem 0 .5rem; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .target { color: #2a7; }
+  .warn {
+    background: #fff3cd; color: #664d03; border: 1px solid #ffe69c;
+    padding: .6rem .8rem; border-radius: 6px;
+  }
+  @media (prefers-color-scheme: dark) {
+    .warn { background: #332701; color: #ffda6a; border-color: #665101; }
+  }
+  form { display: grid; gap: 1rem; margin-top: 1.5rem; }
+  label { display: grid; gap: .3rem; font-weight: 600; }
+  .hint { font-weight: 400; opacity: .7; font-size: .85rem; }
+  select, input, textarea {
+    font: inherit; padding: .5rem; border-radius: 6px;
+    border: 1px solid #8884; background: Field; color: FieldText;
+  }
+  textarea { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .9rem; resize: vertical; }
+  button {
+    font: inherit; font-weight: 600; padding: .55rem 1.2rem; border-radius: 6px;
+    border: 0; background: #2563eb; color: #fff; cursor: pointer; justify-self: start;
+  }
+  button:disabled { background: #8887; cursor: not-allowed; }
+  .error { color: #c33; font-weight: 600; min-height: 1.2em; }
+  ol#log { list-style: none; padding: 0; display: grid; gap: .6rem; }
+  .entry {
+    border: 1px solid #8884; border-left-width: 4px; border-radius: 6px; padding: .7rem .9rem;
+  }
+  .entry.ok { border-left-color: #2a7; }
+  .entry.fail { border-left-color: #c33; }
+  .entry .status { font-weight: 700; }
+  .entry .reason { font-size: .9rem; opacity: .85; margin: .2rem 0; }
+  .entry .meta { font-size: .82rem; opacity: .7; }
+  .entry pre {
+    margin: .4rem 0 0; padding: .5rem; background: #8881; border-radius: 4px;
+    overflow-x: auto; font-size: .82rem; white-space: pre-wrap; word-break: break-word;
+  }
+  .empty { opacity: .6; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Webhook Trigger</h1>
+  {{if .Enabled}}
+  <p class="target">Delivering to <code>{{.URL}}</code></p>
+  {{else}}
+  <p class="warn">No <code>--webhook-url</code> is configured. Set it (the <code>--webhook-url</code> flag or <code>ECWID_MOCK_WEBHOOK_URL</code>) and restart to fire webhooks.</p>
+  {{end}}
+
+  <form id="fire-form">
+    <label>Event
+      <select id="event">
+        {{range .Groups}}<optgroup label="{{.Label}}">{{range .Events}}<option value="{{.}}">{{.}}</option>{{end}}</optgroup>{{end}}
+      </select>
+    </label>
+    <label>entityId <span id="entity-type" class="hint"></span>
+      <input id="entityId" type="text" autocomplete="off" spellcheck="false">
+    </label>
+    <label>data <span id="data-hint" class="hint"></span>
+      <textarea id="data" rows="6" spellcheck="false"></textarea>
+    </label>
+    <label>signature
+      <select id="signature">
+        <option value="valid">valid</option>
+        <option value="invalid">invalid — a good handler must reject</option>
+        <option value="missing">missing — a good handler must reject</option>
+      </select>
+    </label>
+    <button id="fire" type="submit"{{if not .Enabled}} disabled{{end}}>Fire</button>
+    <span id="form-error" class="error"></span>
+  </form>
+
+  <h2>Delivery log</h2>
+  <ol id="log"><li class="empty">No webhooks fired yet.</li></ol>
+</main>
+
+<script>
+const CATALOG = {{.CatalogJSON}};
+(function () {
+  const eventSel = document.getElementById('event');
+  const entityIdEl = document.getElementById('entityId');
+  const entityTypeEl = document.getElementById('entity-type');
+  const dataEl = document.getElementById('data');
+  const dataHintEl = document.getElementById('data-hint');
+  const sigSel = document.getElementById('signature');
+  const form = document.getElementById('fire-form');
+  const fireBtn = document.getElementById('fire');
+  const formErr = document.getElementById('form-error');
+  const log = document.getElementById('log');
+  let logEmpty = true;
+
+  function prefill() {
+    const spec = CATALOG[eventSel.value];
+    if (!spec) return;
+    entityIdEl.value = spec.entityId;
+    entityTypeEl.textContent = '(serialized as a ' + spec.entityIdType + ')';
+    if (spec.hasData) {
+      dataEl.value = JSON.stringify(spec.data, null, 2);
+      dataEl.disabled = false;
+      dataHintEl.textContent = '';
+    } else {
+      dataEl.value = '';
+      dataEl.disabled = true;
+      dataHintEl.textContent = '(this event carries no data key)';
+    }
+  }
+
+  function addLog(res) {
+    if (logEmpty) { log.textContent = ''; logEmpty = false; }
+    const li = document.createElement('li');
+    li.className = 'entry ' + (res.delivered ? 'ok' : 'fail');
+
+    const status = document.createElement('div');
+    status.className = 'status';
+    const code = res.statusCode ? String(res.statusCode) : 'no response';
+    status.textContent = (res.delivered ? '✓ delivered' : '✗ not delivered') +
+      ' — ' + res.eventType + ' — ' + code;
+    li.appendChild(status);
+
+    const reason = document.createElement('div');
+    reason.className = 'reason';
+    reason.textContent = res.error ? res.error : res.reason;
+    li.appendChild(reason);
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.textContent = 'signature: ' + res.signatureMode +
+      ' · entityId: ' + res.entityId + ' (' + res.entityIdType + ')' +
+      ' · ' + res.latencyMs + ' ms · eventId ' + res.eventId;
+    li.appendChild(meta);
+
+    if (res.responseBody) {
+      const pre = document.createElement('pre');
+      pre.textContent = res.responseBody;
+      li.appendChild(pre);
+    }
+
+    log.insertBefore(li, log.firstChild);
+  }
+
+  form.addEventListener('submit', async function (e) {
+    e.preventDefault();
+    formErr.textContent = '';
+    const body = {
+      eventType: eventSel.value,
+      entityId: entityIdEl.value,
+      signature: sigSel.value,
+    };
+    const dataText = dataEl.value.trim();
+    if (!dataEl.disabled && dataText) {
+      try {
+        body.data = JSON.parse(dataText);
+      } catch (err) {
+        formErr.textContent = 'data is not valid JSON: ' + err.message;
+        return;
+      }
+    }
+    fireBtn.disabled = true;
+    try {
+      const resp = await fetch('/_mock/webhooks/trigger', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const result = await resp.json();
+      if (!resp.ok) {
+        formErr.textContent = result.error || ('HTTP ' + resp.status);
+      } else {
+        addLog(result);
+      }
+    } catch (err) {
+      formErr.textContent = 'request failed: ' + err.message;
+    } finally {
+      fireBtn.disabled = false;
+    }
+  });
+
+  eventSel.addEventListener('change', prefill);
+  prefill();
+})();
+</script>
+</body>
+</html>

--- a/mock/internal/webhook/trigger.go
+++ b/mock/internal/webhook/trigger.go
@@ -1,0 +1,308 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/webhooks"
+)
+
+// Delivery timeouts mirror Ecwid's: 3s to connect, 10s for the response.
+const (
+	connectTimeout  = 3 * time.Second
+	responseTimeout = 10 * time.Second
+)
+
+// maxResponseBody caps how much of the endpoint's response body is read back
+// into the result, so a chatty or malicious endpoint cannot balloon a result.
+const maxResponseBody = 4 << 10 // 4 KiB
+
+// SignatureMode selects how a triggered webhook is signed, so a developer can
+// prove their handler fails closed on a bad or absent signature.
+type SignatureMode string
+
+const (
+	// SignatureValid signs with the configured client_secret; the signature
+	// verifies with [webhooks.Verify].
+	SignatureValid SignatureMode = "valid"
+	// SignatureInvalid sends a well-formed but wrong signature; [webhooks.Verify]
+	// rejects it. A handler that accepts it is not verifying.
+	SignatureInvalid SignatureMode = "invalid"
+	// SignatureMissing sends no signature header at all. A handler that accepts it
+	// fails open — the exact bug Ecwid's own PHP example ships.
+	SignatureMissing SignatureMode = "missing"
+)
+
+// valid reports whether m is a known signature mode.
+func (m SignatureMode) valid() bool {
+	switch m {
+	case SignatureValid, SignatureInvalid, SignatureMissing:
+		return true
+	default:
+		return false
+	}
+}
+
+// Request is a webhook trigger. Only EventType is required; EntityID and Data
+// default to the event's fixture, and Mode defaults to [SignatureValid].
+type Request struct {
+	// EventType is the event to fire, e.g. "order.updated".
+	EventType webhooks.EventType
+	// EntityID overrides the fixture entityId. Empty uses the fixture default.
+	EntityID string
+	// Data overrides the fixture data. Nil uses the fixture default; a non-nil
+	// JSON null ("null") forces no data key.
+	Data json.RawMessage
+	// Mode selects signature validity. Empty means [SignatureValid].
+	Mode SignatureMode
+}
+
+// Result is the outcome of a trigger: the composed event, the exact bytes sent,
+// and the delivery verdict. It carries the eventCreated/eventId/signature a test
+// needs to re-verify with [webhooks.Verify].
+type Result struct {
+	EventType     webhooks.EventType `json:"eventType"`
+	EventID       string             `json:"eventId"`
+	EventCreated  int64              `json:"eventCreated"`
+	EntityID      string             `json:"entityId"`
+	EntityIDType  string             `json:"entityIdType"`
+	SignatureMode SignatureMode      `json:"signatureMode"`
+	// Signature is the value sent in the signature header, empty for
+	// [SignatureMissing]. It is not a secret — Ecwid transmits it in the clear —
+	// so it is safe to surface; the client_secret never appears here.
+	Signature   string `json:"signature"`
+	RequestBody string `json:"requestBody"`
+	URL         string `json:"url"`
+
+	// Delivered and Reason classify the response per Ecwid's rules.
+	Delivered bool   `json:"delivered"`
+	Reason    string `json:"reason"`
+	// StatusCode is the endpoint's HTTP status, or 0 when no response arrived.
+	StatusCode int `json:"statusCode"`
+	// ResponseBody is the endpoint's response, truncated to maxResponseBody.
+	ResponseBody string `json:"responseBody"`
+	// LatencyMS is the round-trip time in milliseconds.
+	LatencyMS int64 `json:"latencyMs"`
+	// Error is set when delivery failed before a response (timeout, refused
+	// connection, DNS). It is a transport failure, distinct from a delivered-but-
+	// unsuccessful status.
+	Error string `json:"error,omitempty"`
+}
+
+// ErrNoWebhookURL reports that no delivery target is configured. The UI disables
+// Fire and the control API returns 409 rather than attempting a delivery.
+var ErrNoWebhookURL = errors.New("webhook: no --webhook-url configured")
+
+// ErrUnknownEvent reports an eventType with no fixture.
+var ErrUnknownEvent = errors.New("webhook: unknown event type")
+
+// Trigger composes, signs, and delivers webhooks to a configured URL.
+type Trigger struct {
+	clientSecret string
+	storeID      int64
+	url          string
+	client       *http.Client
+	now          func() time.Time
+}
+
+// Config configures a [Trigger].
+type Config struct {
+	// ClientSecret signs webhooks. Required.
+	ClientSecret string
+	// StoreID is placed in every event's storeId.
+	StoreID int64
+	// URL is the delivery target. Empty disables delivery; the Trigger still
+	// composes events but [Trigger.Fire] returns [ErrNoWebhookURL].
+	URL string
+	// Client overrides the HTTP client. Optional; a client with Ecwid's connect
+	// and response timeouts is used when nil.
+	Client *http.Client
+	// Now overrides the clock, for tests. Optional; defaults to [time.Now].
+	Now func() time.Time
+}
+
+// NewTrigger builds a [Trigger] from cfg.
+func NewTrigger(cfg Config) *Trigger {
+	client := cfg.Client
+	if client == nil {
+		client = &http.Client{
+			Transport: &http.Transport{
+				DialContext:           (&net.Dialer{Timeout: connectTimeout}).DialContext,
+				ResponseHeaderTimeout: responseTimeout,
+			},
+		}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Trigger{
+		clientSecret: cfg.ClientSecret,
+		storeID:      cfg.StoreID,
+		url:          cfg.URL,
+		client:       client,
+		now:          now,
+	}
+}
+
+// Enabled reports whether a delivery URL is configured.
+func (t *Trigger) Enabled() bool { return t.url != "" }
+
+// URL returns the configured delivery target, for display.
+func (t *Trigger) URL() string { return t.url }
+
+// compose builds a signed event and its wire bytes from req, without delivering.
+func (t *Trigger) compose(req Request) (Result, []byte, error) {
+	spec, ok := Lookup(req.EventType)
+	if !ok {
+		return Result{}, nil, fmt.Errorf("%w: %q", ErrUnknownEvent, req.EventType)
+	}
+
+	mode := req.Mode
+	if mode == "" {
+		mode = SignatureValid
+	}
+	if !mode.valid() {
+		return Result{}, nil, fmt.Errorf("webhook: invalid signature mode %q (want valid, invalid, or missing)", mode)
+	}
+
+	entityID := req.EntityID
+	if entityID == "" {
+		entityID = spec.EntityID
+	}
+
+	// Nil Data uses the fixture default; an explicit JSON null forces no data key.
+	data := req.Data
+	if data == nil {
+		data = spec.Data
+	} else if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		data = nil
+	}
+
+	eventID, err := newUUID()
+	if err != nil {
+		return Result{}, nil, fmt.Errorf("webhook: generate eventId: %w", err)
+	}
+	created := t.now().Unix()
+
+	event := webhooks.Event{
+		EventID:      eventID,
+		EventCreated: created,
+		StoreID:      t.storeID,
+		EventType:    req.EventType,
+		EntityID:     entityID,
+		Data:         data,
+	}
+	body, err := json.Marshal(event)
+	if err != nil {
+		return Result{}, nil, fmt.Errorf("webhook: marshal event: %w", err)
+	}
+
+	res := Result{
+		EventType:     req.EventType,
+		EventID:       eventID,
+		EventCreated:  created,
+		EntityID:      entityID,
+		EntityIDType:  spec.EntityIDType(),
+		SignatureMode: mode,
+		Signature:     signature(mode, created, eventID, t.clientSecret),
+		RequestBody:   string(body),
+		URL:           t.url,
+	}
+	return res, body, nil
+}
+
+// signature produces the header value for a mode: a valid signature, a
+// deliberately wrong one, or none.
+func signature(mode SignatureMode, eventCreated int64, eventID, clientSecret string) string {
+	switch mode {
+	case SignatureMissing:
+		return ""
+	case SignatureInvalid:
+		// A real HMAC under a wrong key: well-formed base64 that webhooks.Verify
+		// rejects with a digest mismatch, exactly like a spoofed sender.
+		return webhooks.Sign(eventCreated, eventID, clientSecret+"-wrong-key")
+	default:
+		return webhooks.Sign(eventCreated, eventID, clientSecret)
+	}
+}
+
+// Compose builds and signs an event without delivering it. Useful for tests and
+// for showing the exact payload before firing.
+func (t *Trigger) Compose(req Request) (Result, error) {
+	res, _, err := t.compose(req)
+	return res, err
+}
+
+// Fire composes, signs, and POSTs a webhook, returning the delivery verdict. It
+// returns [ErrNoWebhookURL] if no target is configured and [ErrUnknownEvent] for
+// an unknown event; a reachable endpoint that returns any status yields a Result
+// with no error, its Delivered/Reason set by Ecwid's classification.
+func (t *Trigger) Fire(ctx context.Context, req Request) (Result, error) {
+	if !t.Enabled() {
+		return Result{}, ErrNoWebhookURL
+	}
+
+	res, body, err := t.compose(req)
+	if err != nil {
+		return Result{}, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, fmt.Errorf("webhook: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if res.SignatureMode != SignatureMissing {
+		httpReq.Header.Set(webhooks.SignatureHeader, res.Signature)
+	}
+
+	start := t.now()
+	resp, err := t.client.Do(httpReq)
+	if err != nil {
+		res.LatencyMS = t.now().Sub(start).Milliseconds()
+		res.Reason = "delivery failed before a response (timeout, refused connection, or DNS failure)"
+		res.Error = deliveryError(err)
+		return res, nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	res.LatencyMS = t.now().Sub(start).Milliseconds()
+	res.StatusCode = resp.StatusCode
+	res.ResponseBody = string(respBody)
+
+	verdict := classify(resp.StatusCode)
+	res.Delivered = verdict.Delivered
+	res.Reason = verdict.Reason
+	return res, nil
+}
+
+// deliveryError renders a transport error, mapping a deadline to a message that
+// names the response timeout rather than leaking a raw context string.
+func deliveryError(err error) string {
+	var netErr net.Error
+	if errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
+		return fmt.Sprintf("timed out (connect %s / response %s)", connectTimeout, responseTimeout)
+	}
+	return err.Error()
+}
+
+// newUUID returns a random RFC 4122 version-4 UUID string.
+func newUUID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}

--- a/mock/internal/webhook/trigger_test.go
+++ b/mock/internal/webhook/trigger_test.go
@@ -1,0 +1,282 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/webhooks"
+)
+
+const testSecret = "test_client_secret_1234567890"
+
+func newTestTrigger(t *testing.T, url string) *Trigger {
+	t.Helper()
+	return NewTrigger(Config{ClientSecret: testSecret, StoreID: 1003, URL: url})
+}
+
+// Every catalog event must compose into a body that ecwid/webhooks parses back
+// intact and whose signature verifies with webhooks.Verify — the mock exercising
+// the same code an integration runs is the whole point.
+func TestCompose_AllEventsParseAndVerify(t *testing.T) {
+	tr := newTestTrigger(t, "")
+	for _, spec := range Catalog() {
+		t.Run(string(spec.Type), func(t *testing.T) {
+			res, err := tr.Compose(Request{EventType: spec.Type})
+			if err != nil {
+				t.Fatalf("Compose(%q) error: %v", spec.Type, err)
+			}
+
+			var e webhooks.Event
+			if err := json.Unmarshal([]byte(res.RequestBody), &e); err != nil {
+				t.Fatalf("unmarshal body %q: %v", res.RequestBody, err)
+			}
+			if e.EventType != spec.Type {
+				t.Errorf("eventType = %q, want %q", e.EventType, spec.Type)
+			}
+			if e.EntityID != spec.EntityID {
+				t.Errorf("entityId = %q, want %q", e.EntityID, spec.EntityID)
+			}
+			if e.StoreID != 1003 {
+				t.Errorf("storeId = %d, want 1003", e.StoreID)
+			}
+			if e.EventID != res.EventID || e.EventCreated != res.EventCreated {
+				t.Errorf("event/result eventId/eventCreated mismatch")
+			}
+
+			if err := webhooks.Verify(res.Signature, res.EventCreated, res.EventID, testSecret); err != nil {
+				t.Errorf("Verify() = %v, want nil for a valid signature", err)
+			}
+
+			// Data presence must match the fixture: no key at all when absent.
+			raw := rawFields(t, res.RequestBody)
+			if _, present := raw["data"]; present != spec.HasData() {
+				t.Errorf("data key present = %t, want %t", present, spec.HasData())
+			}
+		})
+	}
+}
+
+// entityId is a bare number for order/product families and a quoted string for
+// application.* — the inconsistency the mock exists to reproduce.
+func TestCompose_EntityIDWireType(t *testing.T) {
+	tr := newTestTrigger(t, "")
+
+	res, err := tr.Compose(Request{EventType: webhooks.EventOrderCreated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw := rawFields(t, res.RequestBody)["entityId"]; raw[0] == '"' {
+		t.Errorf("order.created entityId = %s, want a bare number", raw)
+	}
+
+	res, err = tr.Compose(Request{EventType: webhooks.EventApplicationInstalled})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw := rawFields(t, res.RequestBody)["entityId"]; raw[0] != '"' {
+		t.Errorf("application.installed entityId = %s, want a quoted string", raw)
+	}
+}
+
+// product.created carries no data — the body must omit the key, not send an
+// empty object.
+func TestCompose_ProductHasNoDataKey(t *testing.T) {
+	tr := newTestTrigger(t, "")
+	res, err := tr.Compose(Request{EventType: webhooks.EventProductCreated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := rawFields(t, res.RequestBody)["data"]; present {
+		t.Errorf("product.created body has a data key: %s", res.RequestBody)
+	}
+}
+
+func TestCompose_SignatureModes(t *testing.T) {
+	tr := newTestTrigger(t, "")
+
+	valid, err := tr.Compose(Request{EventType: webhooks.EventOrderCreated, Mode: SignatureValid})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := webhooks.Verify(valid.Signature, valid.EventCreated, valid.EventID, testSecret); err != nil {
+		t.Errorf("valid mode: Verify = %v, want nil", err)
+	}
+
+	invalid, err := tr.Compose(Request{EventType: webhooks.EventOrderCreated, Mode: SignatureInvalid})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if invalid.Signature == "" {
+		t.Error("invalid mode produced an empty signature; it should be a wrong-but-well-formed one")
+	}
+	if err := webhooks.Verify(invalid.Signature, invalid.EventCreated, invalid.EventID, testSecret); !errors.Is(err, webhooks.ErrInvalidSignature) {
+		t.Errorf("invalid mode: Verify = %v, want ErrInvalidSignature", err)
+	}
+
+	missing, err := tr.Compose(Request{EventType: webhooks.EventOrderCreated, Mode: SignatureMissing})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing.Signature != "" {
+		t.Errorf("missing mode signature = %q, want empty", missing.Signature)
+	}
+	if err := webhooks.Verify(missing.Signature, missing.EventCreated, missing.EventID, testSecret); !errors.Is(err, webhooks.ErrInvalidSignature) {
+		t.Errorf("missing mode: Verify = %v, want ErrInvalidSignature", err)
+	}
+}
+
+func TestCompose_DefaultsAndOverrides(t *testing.T) {
+	tr := newTestTrigger(t, "")
+
+	// Empty mode defaults to valid.
+	res, err := tr.Compose(Request{EventType: webhooks.EventOrderCreated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.SignatureMode != SignatureValid {
+		t.Errorf("default mode = %q, want valid", res.SignatureMode)
+	}
+
+	// entityId override is honored.
+	res, err = tr.Compose(Request{EventType: webhooks.EventOrderCreated, EntityID: "999"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.EntityID != "999" {
+		t.Errorf("entityId = %q, want 999", res.EntityID)
+	}
+
+	// Explicit JSON null forces no data key even for a data-bearing event.
+	res, err = tr.Compose(Request{EventType: webhooks.EventOrderCreated, Data: json.RawMessage("null")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, present := rawFields(t, res.RequestBody)["data"]; present {
+		t.Errorf("explicit null data still emitted a data key: %s", res.RequestBody)
+	}
+}
+
+func TestCompose_UnknownEvent(t *testing.T) {
+	tr := newTestTrigger(t, "")
+	if _, err := tr.Compose(Request{EventType: "no.such.event"}); !errors.Is(err, ErrUnknownEvent) {
+		t.Errorf("Compose(unknown) = %v, want ErrUnknownEvent", err)
+	}
+}
+
+func TestFire_Classification(t *testing.T) {
+	tests := []struct {
+		status        int
+		wantDelivered bool
+	}{
+		{200, true}, {201, true}, {202, true}, {204, true}, {209, true},
+		{203, false}, {208, false}, {301, false}, {500, false},
+	}
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			var gotSig string
+			var gotBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotSig = r.Header.Get(webhooks.SignatureHeader)
+				gotBody, _ = io.ReadAll(r.Body)
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			tr := newTestTrigger(t, srv.URL)
+			res, err := tr.Fire(context.Background(), Request{EventType: webhooks.EventOrderCreated})
+			if err != nil {
+				t.Fatalf("Fire error: %v", err)
+			}
+			if res.StatusCode != tt.status {
+				t.Errorf("status = %d, want %d", res.StatusCode, tt.status)
+			}
+			if res.Delivered != tt.wantDelivered {
+				t.Errorf("delivered = %t, want %t (%s)", res.Delivered, tt.wantDelivered, res.Reason)
+			}
+			// The endpoint received a verifiable webhook.
+			var e webhooks.Event
+			if err := json.Unmarshal(gotBody, &e); err != nil {
+				t.Fatalf("endpoint got unparseable body: %v", err)
+			}
+			if err := webhooks.Verify(gotSig, e.EventCreated, e.EventID, testSecret); err != nil {
+				t.Errorf("endpoint could not verify signature: %v", err)
+			}
+		})
+	}
+}
+
+func TestFire_MissingSignatureHeaderAbsent(t *testing.T) {
+	var hadHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadHeader = r.Header[http.CanonicalHeaderKey(webhooks.SignatureHeader)]
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := newTestTrigger(t, srv.URL)
+	if _, err := tr.Fire(context.Background(), Request{EventType: webhooks.EventOrderCreated, Mode: SignatureMissing}); err != nil {
+		t.Fatal(err)
+	}
+	if hadHeader {
+		t.Error("missing mode still sent the signature header")
+	}
+}
+
+func TestFire_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// A client whose response timeout is far below the server's delay, so the
+	// delivery fails on timeout rather than waiting Ecwid's real 10s.
+	tr := NewTrigger(Config{
+		ClientSecret: testSecret,
+		StoreID:      1003,
+		URL:          srv.URL,
+		Client: &http.Client{Transport: &http.Transport{
+			ResponseHeaderTimeout: 50 * time.Millisecond,
+		}},
+	})
+
+	res, err := tr.Fire(context.Background(), Request{EventType: webhooks.EventOrderCreated})
+	if err != nil {
+		t.Fatalf("Fire returned a Go error, want a failed-delivery Result: %v", err)
+	}
+	if res.Delivered {
+		t.Error("timed-out delivery reported as delivered")
+	}
+	if res.StatusCode != 0 {
+		t.Errorf("statusCode = %d, want 0 on timeout", res.StatusCode)
+	}
+	if res.Error == "" {
+		t.Error("timed-out delivery has no Error set")
+	}
+}
+
+func TestFire_NoURL(t *testing.T) {
+	tr := newTestTrigger(t, "")
+	if tr.Enabled() {
+		t.Error("Enabled() = true with no URL")
+	}
+	if _, err := tr.Fire(context.Background(), Request{EventType: webhooks.EventOrderCreated}); !errors.Is(err, ErrNoWebhookURL) {
+		t.Errorf("Fire without URL = %v, want ErrNoWebhookURL", err)
+	}
+}
+
+// rawFields decodes a JSON object into its top-level raw fields.
+func rawFields(t *testing.T, body string) map[string]json.RawMessage {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		t.Fatalf("decode fields from %q: %v", body, err)
+	}
+	return m
+}

--- a/mock/internal/webhook/ui.go
+++ b/mock/internal/webhook/ui.go
@@ -1,0 +1,96 @@
+package webhook
+
+import (
+	"embed"
+	"encoding/json"
+	"html/template"
+	"net/http"
+)
+
+//go:embed templates/panel.html
+var templateFS embed.FS
+
+// panelTemplate is parsed once at startup; a parse failure is a build-time bug in
+// the embedded template, so it panics rather than deferring to request time.
+var panelTemplate = template.Must(template.ParseFS(templateFS, "templates/panel.html"))
+
+// panelData is the data rendered into the trigger UI.
+type panelData struct {
+	// Enabled reports whether a delivery URL is configured. When false the Fire
+	// button is disabled with an explanation rather than erroring on click.
+	Enabled bool
+	// URL is the delivery target, shown for context.
+	URL string
+	// Groups are the event families for the dropdown, in catalog order.
+	Groups []panelGroup
+	// CatalogJSON is the per-event fixture map the page's JS reads to prefill the
+	// entityId and data fields. Go's json escapes <, > and & to \u00xx, so it is
+	// safe to embed inside a <script> block.
+	CatalogJSON template.JS
+}
+
+// panelGroup is one <optgroup> of events.
+type panelGroup struct {
+	Label  string
+	Events []string
+}
+
+// panelEvent is the prefill fixture for one event, keyed by event type in the
+// embedded catalog JSON.
+type panelEvent struct {
+	EntityID     string          `json:"entityId"`
+	EntityIDType string          `json:"entityIdType"`
+	HasData      bool            `json:"hasData"`
+	Data         json.RawMessage `json:"data,omitempty"`
+}
+
+func (h *Handler) handleUI(w http.ResponseWriter, _ *http.Request) {
+	data, err := h.buildPanelData()
+	if err != nil {
+		http.Error(w, "render webhook panel", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if err := panelTemplate.Execute(w, data); err != nil {
+		// Headers are already committed; nothing actionable remains.
+		return
+	}
+}
+
+// buildPanelData assembles the template model from the event catalog.
+func (h *Handler) buildPanelData() (panelData, error) {
+	specs := Catalog()
+
+	// Group events in catalog order, preserving first-seen group order.
+	var groups []panelGroup
+	index := map[string]int{}
+	fixtures := map[string]panelEvent{}
+	for _, s := range specs {
+		g := s.Group()
+		i, ok := index[g]
+		if !ok {
+			i = len(groups)
+			index[g] = i
+			groups = append(groups, panelGroup{Label: g})
+		}
+		groups[i].Events = append(groups[i].Events, string(s.Type))
+		fixtures[string(s.Type)] = panelEvent{
+			EntityID:     s.EntityID,
+			EntityIDType: s.EntityIDType(),
+			HasData:      s.HasData(),
+			Data:         s.Data,
+		}
+	}
+
+	catalogJSON, err := json.Marshal(fixtures)
+	if err != nil {
+		return panelData{}, err
+	}
+
+	return panelData{
+		Enabled:     h.trigger.Enabled(),
+		URL:         h.trigger.URL(),
+		Groups:      groups,
+		CatalogJSON: template.JS(catalogJSON),
+	}, nil
+}


### PR DESCRIPTION
Builds the mock's headline feature: fire any of the 42 Ecwid webhook events by hand from a UI, and drive the same thing from CI over an HTTP control API. Ecwid ships no webhook tooling at all — no test sender, no replay, no delivery log — so this removes the "mutate a real store and wait" loop entirely.

Closes #69.

## Control API (the primary surface — #71's integration tests drive this)

- `POST /_mock/webhooks/trigger` — composes a well-formed event, signs it, POSTs to `--webhook-url`, and returns the delivery result: status, latency, success/failure **classification with its reason**, and response body.
- `GET /_mock/webhooks/events` — the 42 event types with group, `entityId` wire type, and fixture `data`, so clients enumerate without hardcoding.
- `GET /_mock/webhooks/ui` — the trigger panel (stdlib `html/template` + `go:embed`, no JS framework): grouped event dropdown, fixture-prefilled `entityId`/`data`, signature selector, Fire, and a session delivery log. Fire is disabled with an explanation when `--webhook-url` is unset.

## Exercises the real `ecwid/webhooks` code

Events are composed with `webhooks.Event` and signed with the library, not reimplemented — the mock running the same code an integration runs is the whole point. This faithfully reproduces Ecwid's own inconsistencies:

- **`entityId` wire type** — a bare JSON number for order/product families, a quoted string for `application.*`. Verified end-to-end (`order.created` → `103878161`, `application.installed` → `"1003"`).
- **No `data` key** for `product.*`/`category.*`/`discount_coupon.*`/`application.installed`/`uninstalled` and the class/group/GDPR events — the key is omitted, never `"data":{}`.
- **Signature** = `base64(HMAC-SHA256(client_secret, "<eventCreated>.<eventId>"))`, covering only those two fields. `signature=valid|invalid|missing` lets a developer prove their handler fails closed; `invalid` and `missing` are both rejected by `webhooks.Verify`.
- **Delivery classification** per Ecwid's rules: success = `200/201/202/204/209`; failure = `203`, `208`, any other 2xx, and **all 3xx** (the silent-redirect trap). The reason is always reported, e.g. `208 -> NOT delivered: a 2xx Ecwid does not count as success`.
- Timeouts mirror Ecwid (3s connect / 10s response). The 24h/27-attempt retry schedule is deliberately **not** implemented — a dev tool that retries for a day is hostile; it reports the outcome and lets the user re-fire.

## Small additions to `ecwid/webhooks`

To use the library's signing rather than reimplement it (as the issue directs), two symbols are exported, both keyed off values the mock already holds:

- `Sign(eventCreated, eventID, clientSecret)` — the mirror of `Verify`. Signing requires the `client_secret`, so it grants no capability to anyone who doesn't already hold the secret; it makes signing and verification share one MAC so they can't drift.
- `SuccessCodes() []int` — the canonical success set (previously unexported), so the mock's classifier uses exactly what the library enforces.

## Tests

`task mock:test` / `task mock:lint` pass. Coverage includes: all 42 events compose, parse back through `webhooks`, and verify with `webhooks.Verify`; `entityId` typing for `order.created` vs `application.installed`; `product.created` emits no `data` key; the three signature modes; success/failure classification (`200/201/202/204/209` pass, `203/208/301/500` fail); timeout against a slow server; and full-stack trigger/events/UI through the server mux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
