### PR TITLE
fix(mock): apply #81 webhook-trigger review fixes (redirect trap, timeouts, status codes)

### DIFF
--- a/ecwid/webhooks/handler.go
+++ b/ecwid/webhooks/handler.go
@@ -16,26 +16,32 @@ import (
 // unauthenticated POST cannot exhaust memory.
 const maxBodyBytes = 1 << 20 // 1 MiB
 
+// successCodeSet is the canonical set of status codes Ecwid counts as a
+// successful delivery. It is never mutated, so [isSuccessCode] can read it
+// directly and [SuccessCodes] hands out a copy — neither allocates on the check
+// path nor lets a caller mutate the shared source.
+var successCodeSet = [...]int{
+	http.StatusOK,        // 200
+	http.StatusCreated,   // 201
+	http.StatusAccepted,  // 202
+	http.StatusNoContent, // 204
+	209,                  // no net/http constant; not a registered IANA code
+}
+
 // SuccessCodes lists the HTTP status codes Ecwid counts as a successful webhook
 // delivery: 200, 201, 202, 204 and 209. Every other status — including 203, 208
 // and every 3xx — is a failed delivery that Ecwid retries.
 //
-// It returns a fresh slice per call, so there is no package-level state to
-// mutate, and exists so local tooling (the mock server's delivery classifier)
-// applies exactly the set this package enforces rather than a hand-copied one.
+// It returns a fresh slice per call, so a caller cannot mutate the shared set,
+// and exists so local tooling (the mock server's delivery classifier) applies
+// exactly the set this package enforces rather than a hand-copied one.
 func SuccessCodes() []int {
-	return []int{
-		http.StatusOK,        // 200
-		http.StatusCreated,   // 201
-		http.StatusAccepted,  // 202
-		http.StatusNoContent, // 204
-		209,                  // no net/http constant; not a registered IANA code
-	}
+	return slices.Clone(successCodeSet[:])
 }
 
 // isSuccessCode reports whether Ecwid accepts status as a successful delivery.
 func isSuccessCode(status int) bool {
-	return slices.Contains(SuccessCodes(), status)
+	return slices.Contains(successCodeSet[:], status)
 }
 
 // Deduper records which events have been processed, so a replayed or retried

--- a/mock/internal/webhook/http.go
+++ b/mock/internal/webhook/http.go
@@ -62,6 +62,13 @@ func (h *Handler) handleTrigger(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A bad signature mode is a client error; reject it here rather than letting
+	// it surface from Fire as a generic error.
+	if body.Signature != "" && !body.Signature.valid() {
+		writeError(w, http.StatusBadRequest, "signature must be one of: valid, invalid, missing")
+		return
+	}
+
 	res, err := h.trigger.Fire(r.Context(), Request{
 		EventType: webhooks.EventType(body.EventType),
 		EntityID:  entityID,
@@ -76,7 +83,9 @@ func (h *Handler) handleTrigger(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	case err != nil:
-		writeError(w, http.StatusBadRequest, err.Error())
+		// Remaining errors (UUID generation, marshaling, request construction from
+		// a bad configured URL) are server-side, not the caller's fault.
+		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 

--- a/mock/internal/webhook/http_test.go
+++ b/mock/internal/webhook/http_test.go
@@ -78,10 +78,11 @@ func TestHTTP_Trigger_NoURLReturns409(t *testing.T) {
 func TestHTTP_Trigger_BadRequests(t *testing.T) {
 	control := newTestServer(t, "http://127.0.0.1:0")
 	cases := map[string]string{
-		"missing eventType": `{"entityId":1}`,
-		"unknown event":     `{"eventType":"no.such.event"}`,
-		"malformed JSON":    `{`,
-		"unknown field":     `{"eventType":"order.created","nope":1}`,
+		"missing eventType":  `{"entityId":1}`,
+		"unknown event":      `{"eventType":"no.such.event"}`,
+		"malformed JSON":     `{`,
+		"unknown field":      `{"eventType":"order.created","nope":1}`,
+		"bad signature mode": `{"eventType":"order.created","signature":"bogus"}`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/mock/internal/webhook/trigger.go
+++ b/mock/internal/webhook/trigger.go
@@ -138,6 +138,13 @@ func NewTrigger(cfg Config) *Trigger {
 				DialContext:           (&net.Dialer{Timeout: connectTimeout}).DialContext,
 				ResponseHeaderTimeout: responseTimeout,
 			},
+			// Do not follow redirects: Ecwid does not, so an endpoint that 301s
+			// (e.g. HTTP->HTTPS) silently never receives the webhook. Surfacing
+			// that is a headline goal — following the redirect would hide it and
+			// mislabel the delivery as a success.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		}
 	}
 	now := cfg.Now
@@ -255,6 +262,11 @@ func (t *Trigger) Fire(ctx context.Context, req Request) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+
+	// Bound the whole exchange, so a stalled body read cannot exceed Ecwid's
+	// budget: ResponseHeaderTimeout caps only time-to-first-header, not the body.
+	ctx, cancel := context.WithTimeout(ctx, connectTimeout+responseTimeout)
+	defer cancel()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, t.url, bytes.NewReader(body))
 	if err != nil {

--- a/mock/internal/webhook/trigger_test.go
+++ b/mock/internal/webhook/trigger_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -215,9 +216,11 @@ func TestFire_Classification(t *testing.T) {
 // it — Ecwid does not — so the delivery is reported as the 3xx, not the 200 it
 // would redirect to. This is the trap the tool exists to surface.
 func TestFire_DoesNotFollowRedirects(t *testing.T) {
-	var followed bool
+	// atomic: the target handler runs on the server goroutine, the assertion on
+	// the test goroutine.
+	var followed atomic.Bool
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		followed = true
+		followed.Store(true)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer target.Close()
@@ -232,7 +235,7 @@ func TestFire_DoesNotFollowRedirects(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if followed {
+	if followed.Load() {
 		t.Error("mock followed the redirect; Ecwid does not")
 	}
 	if res.StatusCode != http.StatusMovedPermanently {

--- a/mock/internal/webhook/trigger_test.go
+++ b/mock/internal/webhook/trigger_test.go
@@ -211,6 +211,38 @@ func TestFire_Classification(t *testing.T) {
 	}
 }
 
+// A real redirecting endpoint sends a Location header. The mock must NOT follow
+// it — Ecwid does not — so the delivery is reported as the 3xx, not the 200 it
+// would redirect to. This is the trap the tool exists to surface.
+func TestFire_DoesNotFollowRedirects(t *testing.T) {
+	var followed bool
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		followed = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Redirect(w, &http.Request{}, target.URL, http.StatusMovedPermanently)
+	}))
+	defer redirector.Close()
+
+	tr := newTestTrigger(t, redirector.URL)
+	res, err := tr.Fire(context.Background(), Request{EventType: webhooks.EventOrderCreated})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if followed {
+		t.Error("mock followed the redirect; Ecwid does not")
+	}
+	if res.StatusCode != http.StatusMovedPermanently {
+		t.Errorf("statusCode = %d, want 301 (the redirect itself)", res.StatusCode)
+	}
+	if res.Delivered {
+		t.Errorf("301 reported as delivered: %s", res.Reason)
+	}
+}
+
 func TestFire_MissingSignatureHeaderAbsent(t *testing.T) {
 	var hadHeader bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/mock/internal/webhook/ui.go
+++ b/mock/internal/webhook/ui.go
@@ -1,6 +1,7 @@
 package webhook
 
 import (
+	"bytes"
 	"embed"
 	"encoding/json"
 	"html/template"
@@ -50,11 +51,15 @@ func (h *Handler) handleUI(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "render webhook panel", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := panelTemplate.Execute(w, data); err != nil {
-		// Headers are already committed; nothing actionable remains.
+	// Render into a buffer so a template error becomes a clean 500 rather than a
+	// half-written 200 with a truncated page.
+	var buf bytes.Buffer
+	if err := panelTemplate.Execute(&buf, data); err != nil {
+		http.Error(w, "render webhook panel", http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = buf.WriteTo(w)
 }
 
 // buildPanelData assembles the template model from the event catalog.


### PR DESCRIPTION
Follow-up to #81. That PR was merged at its first commit before its review-fix commit synced to the PR head (a GitHub PR-head sync lag left the pushed fixes off `main`), so the Copilot review corrections never landed. This carries them.

All four were raised on #81, replied to, and the threads resolved; this just gets the code onto `main`.

## Fixes

- **Delivery no longer follows redirects** (the important one). The default `http.Client` follows 301/302/307, which silently defeated the headline "3xx redirect trap" — a redirecting endpoint would be marked *delivered*. `CheckRedirect` now returns `http.ErrUseLastResponse`, so the 3xx is surfaced as-is. New `TestFire_DoesNotFollowRedirects` (a 301 with a `Location` to a live 200 server) asserts the target is never hit and the delivery reports 301, not delivered. The original test only passed because it returned a bare 301 with no `Location`.
- **Bounded end-to-end timeout.** `ResponseHeaderTimeout` caps only time-to-first-header; the request is now wrapped in `context.WithTimeout(connectTimeout+responseTimeout)` so a stalled body read is bounded too.
- **Correct HTTP status mapping.** A bad `signature` mode is validated in `handleTrigger` → 400; genuine server-side failures from `Fire` (UUID generation, marshaling, request construction) now map to 500 instead of 400. `ErrNoWebhookURL` stays 409, `ErrUnknownEvent` stays 400. Added a bad-signature-mode case to `TestHTTP_Trigger_BadRequests`.
- **Buffered UI render.** `handleUI` renders into a `bytes.Buffer` and only writes the 200 once `Execute` succeeds, so a template error returns a clean 500 instead of a half-written page.
- **`webhooks` success-code set** shares one immutable package array: `isSuccessCode` reads it directly (no allocation) and `SuccessCodes()` returns a `slices.Clone`.

`task mock:test` / `task mock:lint` and the `ecwid/webhooks` tests/lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
