### PR TITLE
ci: pass repo-token to arduino/setup-task to avoid API rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.1
       - run: task lint
@@ -38,6 +39,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: task test
 
   build:
@@ -52,5 +54,6 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: task build
       - run: ./bin/ecwid version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,7 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run E2E tests
         if: steps.secrets-check.outputs.has_secrets == 'true'


### PR DESCRIPTION
## Problem

The `Install Task` step in CI failed with:

```
API rate limit exceeded for 172.185.55.131.
```

`arduino/setup-task@v2` downloads Task from the GitHub releases API. Without a token it uses the **unauthenticated, shared per-IP rate limit (60/hr)**, which gets exhausted on busy hosted runners — an intermittent, non-deterministic failure unrelated to the code under test.

## Fix

Pass `repo-token: ${{ secrets.GITHUB_TOKEN }}` to every `arduino/setup-task@v2` step (3 in `ci.yml`, 1 in `e2e.yml`). The download then authenticates and uses the 5,000/hr authenticated limit.

No extra permissions required — `GITHUB_TOKEN` is always available and read access is sufficient for release downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved continuous integration and end-to-end workflow authentication.
  - Updated automated setup steps to access required repository resources reliably.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->