### PR TITLE
feat(mock): built-in profile + customer REST fixtures with scope gating and seeding

### DIFF
--- a/mock/AGENTS.md
+++ b/mock/AGENTS.md
@@ -20,7 +20,7 @@ exactly one namespace each.
 | Prefix | Purpose | Owner issue |
 |--------|---------|-------------|
 | `/` | Admin shell — the developer-facing UI that hosts the app iframe | #4 |
-| `/api/v3/{storeId}/...` | Simulated Ecwid REST; proxy or `501` fallback for unimplemented routes | #5, #7 |
+| `/api/v3/{storeId}/...` | Simulated Ecwid REST: app storage, store-profile + customer fixtures; proxy or `501` fallback for unimplemented routes | #5, #7 |
 
 **REST fallback (`internal/server/proxy.go`).** Unimplemented REST routes return an
 informative `501` naming the endpoint and the `--proxy-store`/`--proxy-token`
@@ -33,7 +33,18 @@ which the "CRUCIAL RULE" forbids). `--proxy-readonly` (default **true**) blocks
 proxied mutations with `403`. **`/storage` is always served locally**, even when
 proxying, so dev scratch state never lands in the real store's app storage —
 enforced in the fallback handler and by ServeMux route specificity.
-| `/_mock/...` | The mock's own control API (health, webhook trigger, …) | #6 |
+
+**Fixtures (`internal/server/fixtures.go`).** `GET /profile`, `GET /customers`
+(paged + `?email=` filter), `GET /customers/{id}`, and `PUT /customers/{id}`
+(field-merge, read-after-write) are served from an in-memory `fixtureStore`
+keyed by store ID — the **default**, no proxy needed. Responses use the
+`ecwid/customers` and `ecwid/profile` structs so shapes/field-names match the
+typed client. Each route is gated on its Ecwid scope via `Config.HasScope`
+(missing scope → the real `403` shape; empty `--scopes` grants all). The
+configured store is seeded with a default profile + customers at `New()`;
+`POST/PUT /_mock/fixtures/...` (control plane) lets an out-of-process consumer
+install its own. These routes are **always local, never proxied**.
+| `/_mock/...` | The mock's own control API (health, webhook trigger, fixtures, …) | #6 |
 
 The `/_mock/` prefix is reserved so the mock's control plane can **never collide
 with a real Ecwid REST route** (real routes live under `/api/v3/`). Register
@@ -66,7 +77,9 @@ mock/
         ├── server.go           # New, routes, Run (graceful shutdown)
         ├── middleware.go       # structured slog request logging
         ├── health.go           # GET /_mock/health
-        └── storage.go          # app-storage REST endpoints (the JS SDK's only HTTP calls)
+        ├── storage.go          # app-storage REST endpoints (the JS SDK's only HTTP calls)
+        ├── fixtures.go         # profile + customer fixtures: store, seed data, REST handlers, scope gate
+        └── fixtures_control.go # POST/PUT /_mock/fixtures/... to seed/override fixtures
 ```
 
 ## Webhook trigger (control plane)
@@ -108,6 +121,7 @@ Precedence is **flags > env > defaults**, matching `config/`'s behavior.
 | `--auth-mode` | `ECWID_MOCK_AUTH_MODE` | `default` | `default` (hex fragment) \| `enhanced` (AES query) |
 | `--webhook-url` | `ECWID_MOCK_WEBHOOK_URL` | *(optional)* | Where triggered webhooks POST |
 | `--access-token` | `ECWID_MOCK_ACCESS_TOKEN` | *(generated)* | `access_token` issued in the payload; required as `Bearer` on REST calls |
+| `--scopes` | `ECWID_MOCK_SCOPES` | *(all granted)* | Comma-separated granted scopes; gates the profile/customer fixtures. Empty = all granted; narrow it to test `403` paths |
 | `--port` | `ECWID_MOCK_PORT` | `8080` | Listen port |
 | `--proxy-store` / `--proxy-token` | `ECWID_MOCK_PROXY_*` | *(optional)* | Forward unimplemented REST to a real store (both required together) |
 | `--proxy-readonly` | `ECWID_MOCK_PROXY_READONLY` | `true` | Only proxy `GET`/`HEAD`; mutations → `403`. Off = proxied writes hit the real store |

--- a/mock/README.md
+++ b/mock/README.md
@@ -9,7 +9,9 @@ module fills that gap:
 - **Admin shell** — serves your app in an iframe with a correctly-built auth
   payload, exactly as Ecwid's admin does.
 - **Simulated REST** — the app-storage endpoints the JS SDK calls over HTTP,
-  with an optional proxy to a real store for everything else.
+  plus built-in **store-profile and customer fixtures** so an app can be
+  exercised without a real store, with an optional proxy to a real store for
+  everything else.
 - **Webhook trigger** — compose, sign, and deliver any of Ecwid's 42 event types,
   including deliberately-invalid signatures to prove your handler fails closed.
 
@@ -170,11 +172,79 @@ handler **rejects** them:
 If your endpoint returns success for `invalid` or `missing`, it is not verifying.
 `webhooks.NewHandler` gets this right; a hand-rolled handler often does not.
 
+## Simulated REST fixtures — run without a real store
+
+Beyond app storage, the mock serves a set of read/write REST endpoints from
+in-memory **fixtures**. These are the **default** — no real store and no proxy
+are needed — so a consuming app (and its integration tests) can be driven
+hermetically. Responses match real Ecwid shapes and field names; they are built
+from the [`ecwid/customers`](https://pkg.go.dev/github.com/matthiasbruns/ecwid-go/ecwid/customers)
+and [`ecwid/profile`](https://pkg.go.dev/github.com/matthiasbruns/ecwid-go/ecwid/profile)
+types, so the mock and the typed client agree by construction.
+
+| Method & path | Scope | Behaviour |
+|---------------|-------|-----------|
+| `GET /api/v3/{storeId}/profile` | `read_store_profile` | The store profile. |
+| `GET /api/v3/{storeId}/customers` | `read_customers` | Paged list (`items`/`count`/`total`/`offset`/`limit`); `?offset=`/`?limit=` window it, `?email=` filters to the case-insensitive match (the *find-by-email* path). |
+| `GET /api/v3/{storeId}/customers/{id}` | `read_customers` | A single customer, or `404`. |
+| `PUT /api/v3/{storeId}/customers/{id}` | `update_customers` | Merges the supplied fields (e.g. `acceptMarketing`) into the stored customer and returns `{"updateCount":1}`. The write is reflected in subsequent `GET`s (read-after-write). |
+
+Requests carry the mock's `access_token` as `Bearer` (a wrong/missing token is
+`401`), exactly like the storage routes. **These endpoints are always served
+locally and never proxied**, even with proxying enabled.
+
+**Seeded defaults.** On startup the configured store is seeded with a store
+profile and three customers (`ada@example.com`, `grace@example.com`,
+`alan@example.com`), so the happy path answers out of the box:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" localhost:8080/api/v3/1003/profile
+curl -H "Authorization: Bearer $TOKEN" "localhost:8080/api/v3/1003/customers?email=grace@example.com"
+```
+
+### Scope enforcement — testing the unhappy path
+
+By default every scope is granted. Narrow the grant with `--scopes` (comma
+-separated) to make an endpoint return the same `403` a real store returns when
+its token lacks the scope:
+
+```bash
+go run ./mock serve --app-url=http://localhost:3000 \
+  --scopes=read_store_profile,read_customers      # update_customers now → 403
+```
+
+```json
+{"errorMessage":"This method requires the 'update_customers' access scope, which the access token was not granted."}
+```
+
+### Seeding your own fixtures
+
+A control API under `/_mock/fixtures/` lets an out-of-process consumer (e.g. an
+E2E suite that boots the mock as a subprocess) install its own fixtures before
+driving the endpoints above. It needs no bearer token. Add `?storeId=` to target
+a specific store (default: the configured store), which is how a multi-tenant
+consumer seeds several stores against one mock.
+
+```bash
+# Upsert one customer (or POST a JSON array to seed many). A missing id is assigned.
+curl -X POST localhost:8080/_mock/fixtures/customers \
+  -d '{"name":"Katherine Johnson","email":"katherine@example.com","acceptMarketing":false}'
+# -> {"id":1004}
+
+# Replace the store profile.
+curl -X PUT localhost:8080/_mock/fixtures/profile \
+  -d '{"settings":{"storeName":"Acme Test Store"}}'
+```
+
+The seeded customer is then findable through the simulated REST endpoints
+(`GET /customers?email=…`), and its `acceptMarketing` can be flipped through the
+real `PUT /customers/{id}` above.
+
 ## Proxy mode — forward the rest to a real store
 
-The mock implements the app-storage endpoints locally. Every other REST route
-returns an informative `501` unless you enable proxying, which forwards
-unimplemented routes to a **real** store:
+The mock implements the app-storage, profile, and customer endpoints locally.
+Every other REST route returns an informative `501` unless you enable proxying,
+which forwards unimplemented routes to a **real** store:
 
 ```bash
 go run ./mock serve --app-url=http://localhost:3000 \
@@ -201,6 +271,7 @@ Precedence is **flags > env > defaults**.
 | `--store-id` | `ECWID_MOCK_STORE_ID` | `1003` | Store ID placed in the payload |
 | `--auth-mode` | `ECWID_MOCK_AUTH_MODE` | `default` | `default` (hex fragment) \| `enhanced` (AES query) |
 | `--access-token` | `ECWID_MOCK_ACCESS_TOKEN` | *(generated)* | `access_token` required as `Bearer` on simulated REST calls |
+| `--scopes` | `ECWID_MOCK_SCOPES` | *(all granted)* | Comma-separated access scopes the token is granted; narrow it to test scope-denied (`403`) paths |
 | `--webhook-url` | `ECWID_MOCK_WEBHOOK_URL` | *(optional)* | Where triggered webhooks POST |
 | `--port` | `ECWID_MOCK_PORT` | `8080` | Listen port |
 | `--proxy-store` | `ECWID_MOCK_PROXY_STORE` | *(optional)* | Store ID to forward unimplemented REST calls to |
@@ -215,10 +286,12 @@ generated `client_secret` is printed in the banner; a user-supplied one never is
 
 It is a developer tool, not a store emulator. It intentionally omits:
 
-- **No product / order / category / customer fixtures.** The only REST endpoints
-  served locally are app storage. Everything else is `501` (or proxied).
-- **No OAuth scope enforcement.** Any token the mock issued authenticates every
-  storage call; the mock does not check `read_orders`, `read_catalog`, etc.
+- **No product / order / category fixtures.** The REST endpoints served locally
+  are app storage plus the store-profile and customer fixtures above. Everything
+  else is `501` (or proxied).
+- **Scope enforcement is limited to the fixture endpoints.** The profile and
+  customer routes honour their required scopes (see `--scopes`); storage and
+  other routes are not scope-gated.
 - **No webhook retry schedule.** A real failed delivery is retried 27 times over
   24h (see the gotchas). The mock fires once and reports the outcome — re-fire
   manually to test your retry handling.

--- a/mock/cmd/serve.go
+++ b/mock/cmd/serve.go
@@ -35,6 +35,7 @@ func init() {
 	f.String("proxy-store", "", "store ID to forward unimplemented REST calls to (env: ECWID_MOCK_PROXY_STORE)")
 	f.String("proxy-token", "", "access token for the proxy store (env: ECWID_MOCK_PROXY_TOKEN)")
 	f.String("access-token", "", "access_token issued in the payload and required as Bearer on REST calls; generated if unset (env: ECWID_MOCK_ACCESS_TOKEN)")
+	f.String("scopes", "", "comma-separated access scopes the token is granted; empty grants all (default). Narrow it to test scope-denied (403) paths, e.g. read_store_profile,read_customers (env: ECWID_MOCK_SCOPES)")
 	f.Bool("proxy-readonly", config.DefaultProxyReadonly, "only proxy GET/HEAD; block proxied mutations (they hit the real store and fire real webhooks) (env: ECWID_MOCK_PROXY_READONLY)")
 
 	rootCmd.AddCommand(serveCmd)

--- a/mock/internal/config/config.go
+++ b/mock/internal/config/config.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -113,6 +114,23 @@ type Config struct {
 	// supplied. When true, the startup banner prints it so the developer can
 	// configure their app to match.
 	SecretGenerated bool
+
+	// Scopes is the set of Ecwid access scopes the mock's token is granted. It
+	// gates the simulated REST endpoints: a request needing a scope not in this
+	// set gets the same 403 a real store returns, so a consumer can exercise the
+	// unhappy path. An empty set means "all scopes granted" (the default), so the
+	// fixtures answer the happy path with no configuration.
+	Scopes []string
+}
+
+// HasScope reports whether the mock's token is granted scope. An empty Scopes
+// set grants everything — the out-of-the-box default so fixtures just work;
+// configure --scopes to a narrower set to test scope-denied paths.
+func (c *Config) HasScope(scope string) bool {
+	if len(c.Scopes) == 0 {
+		return true
+	}
+	return slices.Contains(c.Scopes, scope)
 }
 
 // RedactedClientSecret returns the client_secret with all but the last 4
@@ -209,6 +227,7 @@ func Load(cmd *cobra.Command) (Config, error) {
 	cfg.ProxyStore = resolveString(cmd, "proxy-store", "ECWID_MOCK_PROXY_STORE", "")
 	cfg.ProxyToken = resolveString(cmd, "proxy-token", "ECWID_MOCK_PROXY_TOKEN", "")
 	cfg.AccessToken = resolveString(cmd, "access-token", "ECWID_MOCK_ACCESS_TOKEN", "")
+	cfg.Scopes = parseScopes(resolveString(cmd, "scopes", "ECWID_MOCK_SCOPES", ""))
 
 	port, err := resolvePort(cmd)
 	if err != nil {
@@ -240,6 +259,22 @@ func Load(cmd *cobra.Command) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// parseScopes splits a comma-separated scope list into a trimmed, non-empty
+// slice. An empty or all-whitespace input yields nil, which HasScope treats as
+// "all scopes granted".
+func parseScopes(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var scopes []string
+	for s := range strings.SplitSeq(raw, ",") {
+		if s = strings.TrimSpace(s); s != "" {
+			scopes = append(scopes, s)
+		}
+	}
+	return scopes
 }
 
 // resolveString applies flags > env > default for a string value.

--- a/mock/internal/config/config_test.go
+++ b/mock/internal/config/config_test.go
@@ -22,8 +22,68 @@ func newCmd() *cobra.Command {
 	f.String("proxy-store", "", "")
 	f.String("proxy-token", "", "")
 	f.String("access-token", "", "")
+	f.String("scopes", "", "")
 	f.Bool("proxy-readonly", DefaultProxyReadonly, "")
 	return cmd
+}
+
+func TestHasScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes []string
+		query  string
+		want   bool
+	}{
+		{name: "empty set grants everything", scopes: nil, query: "read_customers", want: true},
+		{name: "granted scope is allowed", scopes: []string{"read_customers", "update_customers"}, query: "read_customers", want: true},
+		{name: "withheld scope is denied", scopes: []string{"read_store_profile"}, query: "read_customers", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{Scopes: tc.scopes}
+			if got := c.HasScope(tc.query); got != tc.want {
+				t.Errorf("HasScope(%q) with %v = %v, want %v", tc.query, tc.scopes, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseScopes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "empty is nil", raw: "", want: nil},
+		{name: "whitespace is nil", raw: "  ", want: nil},
+		{name: "trims and splits", raw: " read_customers , update_customers ", want: []string{"read_customers", "update_customers"}},
+		{name: "drops empty entries", raw: "read_customers,,", want: []string{"read_customers"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseScopes(tc.raw)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("parseScopes(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoad_Scopes(t *testing.T) {
+	cmd := newCmd()
+	if err := cmd.Flags().Set("scopes", "read_store_profile,read_customers"); err != nil {
+		t.Fatalf("set scopes flag: %v", err)
+	}
+	cfg, err := Load(cmd)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.HasScope("read_customers") {
+		t.Error("expected read_customers to be granted")
+	}
+	if cfg.HasScope("update_customers") {
+		t.Error("expected update_customers to be withheld")
+	}
 }
 
 func TestLoad_Defaults(t *testing.T) {

--- a/mock/internal/server/fixtures.go
+++ b/mock/internal/server/fixtures.go
@@ -1,0 +1,396 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"maps"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/customers"
+	"github.com/matthiasbruns/ecwid-go/ecwid/profile"
+)
+
+// Ecwid access scopes gated by the simulated REST endpoints. A request whose
+// token was not granted the required scope gets the same 403 a real store
+// returns, so a consumer can exercise the unhappy path (see Config.HasScope).
+const (
+	scopeReadStoreProfile = "read_store_profile"
+	scopeReadCustomers    = "read_customers"
+	scopeUpdateCustomers  = "update_customers"
+)
+
+// Customers paging bounds, matching the real API: the default page size when no
+// limit is given and the hard cap Ecwid enforces on limit.
+const (
+	defaultCustomersLimit = 100
+	maxCustomersLimit     = 100
+
+	// maxCustomerBodyBytes bounds a customer-update request body so a runaway
+	// client cannot make the mock buffer without limit. A customer record is
+	// small; 1 MB is generous.
+	maxCustomerBodyBytes = 1 << 20
+)
+
+// fixtureStore is the mock's in-memory backing for the simulated customer and
+// store-profile endpoints. It is the default source of truth for those routes
+// so the mock needs no real store and no proxy to answer them. It is keyed by
+// store ID (the {storeId} path segment) so a multi-tenant consumer can seed and
+// exercise several stores against one mock. Safe for concurrent use.
+type fixtureStore struct {
+	mu        sync.RWMutex
+	profiles  map[string]*profile.Profile             // storeID -> profile
+	customers map[string]map[int64]customers.Customer // storeID -> id -> customer
+}
+
+// newFixtureStore returns an empty fixture store.
+func newFixtureStore() *fixtureStore {
+	return &fixtureStore{
+		profiles:  make(map[string]*profile.Profile),
+		customers: make(map[string]map[int64]customers.Customer),
+	}
+}
+
+// setProfile installs the store profile for storeID, replacing any existing one.
+func (fs *fixtureStore) setProfile(storeID string, p *profile.Profile) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	fs.profiles[storeID] = p
+}
+
+// getProfile returns the seeded profile for storeID and whether one is present.
+func (fs *fixtureStore) getProfile(storeID string) (*profile.Profile, bool) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	p, ok := fs.profiles[storeID]
+	return p, ok
+}
+
+// putCustomer upserts a customer under storeID. A customer with a zero ID is
+// assigned the next free ID; the assigned (or supplied) ID is returned.
+func (fs *fixtureStore) putCustomer(storeID string, c customers.Customer) int64 {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.customers[storeID] == nil {
+		fs.customers[storeID] = make(map[int64]customers.Customer)
+	}
+	if c.ID == 0 {
+		c.ID = fs.allocIDLocked(storeID)
+	}
+	fs.customers[storeID][c.ID] = c
+	return c.ID
+}
+
+// allocIDLocked returns an unused customer ID for storeID: one past the highest
+// existing ID, floored so generated IDs stay in a plausible range. Callers must
+// hold the write lock.
+func (fs *fixtureStore) allocIDLocked(storeID string) int64 {
+	var maxID int64 = 1000
+	for id := range fs.customers[storeID] {
+		if id > maxID {
+			maxID = id
+		}
+	}
+	return maxID + 1
+}
+
+// getCustomer returns a customer by ID for storeID and whether it exists.
+func (fs *fixtureStore) getCustomer(storeID string, id int64) (customers.Customer, bool) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	c, ok := fs.customers[storeID][id]
+	return c, ok
+}
+
+// searchCustomers returns a page of customers for storeID in the paged envelope
+// the real API uses (items/count/total/offset/limit). When email is non-empty
+// only customers whose email matches case-insensitively are returned, which is
+// how FindCustomerByEmail narrows the list. Results are ordered by ID so paging
+// is deterministic.
+func (fs *fixtureStore) searchCustomers(storeID, email string, offset, limit int) customers.SearchResult {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	store := fs.customers[storeID]
+	matched := make([]customers.Customer, 0, len(store))
+	for id := range store {
+		if email != "" && !strings.EqualFold(store[id].Email, email) {
+			continue
+		}
+		matched = append(matched, store[id])
+	}
+	sort.Slice(matched, func(i, j int) bool { return matched[i].ID < matched[j].ID })
+
+	total := len(matched)
+	lo := min(offset, total)
+	hi := min(lo+limit, total)
+	page := matched[lo:hi]
+
+	return customers.SearchResult{
+		Total:  total,
+		Count:  len(page),
+		Offset: offset,
+		Limit:  limit,
+		Items:  page,
+	}
+}
+
+// patchCustomer applies a partial update to the customer identified by id under
+// storeID and returns the merged customer. The patch is a set of raw JSON fields
+// (as the SDK sends on PUT /customers/{id}); every supplied field overwrites the
+// stored one while untouched fields are preserved, so a subsequent GET reflects
+// the write (e.g. flipping acceptMarketing). The ID is immutable. The bool
+// reports whether the customer existed; a non-nil error means the merge produced
+// invalid JSON.
+func (fs *fixtureStore) patchCustomer(storeID string, id int64, patch map[string]json.RawMessage) (customers.Customer, bool, error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	existing, ok := fs.customers[storeID][id]
+	if !ok {
+		return customers.Customer{}, false, nil
+	}
+
+	raw, err := json.Marshal(existing)
+	if err != nil {
+		return customers.Customer{}, true, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return customers.Customer{}, true, err
+	}
+	maps.Copy(fields, patch)
+	merged, err := json.Marshal(fields)
+	if err != nil {
+		return customers.Customer{}, true, err
+	}
+	var updated customers.Customer
+	if err := json.Unmarshal(merged, &updated); err != nil {
+		return customers.Customer{}, true, err
+	}
+	updated.ID = id // the path ID is authoritative; a body cannot re-key a customer.
+	fs.customers[storeID][id] = updated
+	return updated, true, nil
+}
+
+// seedDefaults installs a ready-to-use store profile and a small deterministic
+// customer set for storeID, so the fixtures answer the happy path out of the box
+// with no seeding required by the consumer.
+func seedDefaults(fs *fixtureStore, storeID string) {
+	fs.setProfile(storeID, defaultProfile(storeID))
+	seeds := defaultCustomers()
+	for i := range seeds {
+		fs.putCustomer(storeID, seeds[i])
+	}
+}
+
+// defaultProfile builds a realistic, minimal store profile for storeID using the
+// ecwid/profile types, so the mock's shape and field names match the typed
+// client exactly.
+func defaultProfile(storeID string) *profile.Profile {
+	id, _ := strconv.ParseInt(storeID, 10, 64) // non-numeric store IDs simply yield 0.
+	return &profile.Profile{
+		GeneralInfo: &profile.GeneralInfo{
+			StoreID:  id,
+			StoreURL: "https://mystore.example.com",
+		},
+		Account: &profile.Account{
+			AccountName:  "Mock Store Owner",
+			AccountEmail: "owner@example.com",
+		},
+		Settings: &profile.Settings{
+			StoreName: "Mock Store",
+		},
+		Company: &profile.Company{
+			CompanyName: "Mock Store",
+			Email:       "store@example.com",
+			CountryCode: "US",
+		},
+		FormatsAndUnits: &profile.FormatsAndUnits{
+			Currency:       "USD",
+			CurrencyPrefix: "$",
+			WeightUnit:     "LB",
+			Timezone:       "America/New_York",
+		},
+		Languages: &profile.Languages{
+			EnabledLanguages: []string{"en"},
+			DefaultLanguage:  "en",
+		},
+	}
+}
+
+// defaultCustomers is the deterministic starter customer set. It deliberately
+// covers the shapes a consumer tests against: a known email to find, and both
+// acceptMarketing states (including one set to false, ready to be flipped true).
+func defaultCustomers() []customers.Customer {
+	return []customers.Customer{
+		{
+			ID:              1001,
+			Name:            "Ada Lovelace",
+			Email:           "ada@example.com",
+			Registered:      "2024-01-15 10:30:00 +0000",
+			Updated:         "2024-01-15 10:30:00 +0000",
+			AcceptMarketing: boolPtr(true),
+			Lang:            "en",
+		},
+		{
+			ID:              1002,
+			Name:            "Grace Hopper",
+			Email:           "grace@example.com",
+			Registered:      "2024-02-20 09:00:00 +0000",
+			Updated:         "2024-02-20 09:00:00 +0000",
+			AcceptMarketing: boolPtr(false),
+			Lang:            "en",
+		},
+		{
+			ID:              1003,
+			Name:            "Alan Turing",
+			Email:           "alan@example.com",
+			Registered:      "2024-03-10 14:45:00 +0000",
+			Updated:         "2024-03-10 14:45:00 +0000",
+			AcceptMarketing: boolPtr(false),
+			Lang:            "en",
+		},
+	}
+}
+
+// boolPtr returns a pointer to b, for the *bool fields in the ecwid types.
+func boolPtr(b bool) *bool { return &b }
+
+// requireAuthScope gates a simulated REST request on both the mock's bearer
+// token and the required Ecwid scope. A missing/wrong token yields 401 (as the
+// storage routes do); a valid token that lacks the scope yields the 403 shape a
+// real store returns. It returns true only when the request may proceed.
+func (s *Server) requireAuthScope(w http.ResponseWriter, r *http.Request, scope string) bool {
+	if !s.authorized(r) {
+		writeJSONError(w, http.StatusUnauthorized, "invalid or missing access token")
+		return false
+	}
+	if !s.cfg.HasScope(scope) {
+		writeJSONError(w, http.StatusForbidden,
+			"This method requires the '"+scope+"' access scope, which the access token was not granted.")
+		return false
+	}
+	return true
+}
+
+// handleProfileGet serves GET /api/v3/{storeId}/profile (scope
+// read_store_profile). A store with no seeded profile falls back to a generated
+// default so the endpoint is never empty.
+func (s *Server) handleProfileGet(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthScope(w, r, scopeReadStoreProfile) {
+		return
+	}
+	storeID := r.PathValue("storeId")
+	p, ok := s.fixtures.getProfile(storeID)
+	if !ok {
+		p = defaultProfile(storeID)
+	}
+	writeJSON(w, http.StatusOK, p)
+}
+
+// handleCustomersSearch serves GET /api/v3/{storeId}/customers (scope
+// read_customers): a paged customer list, optionally narrowed by ?email= (the
+// FindCustomerByEmail path) and windowed by ?offset= / ?limit=.
+func (s *Server) handleCustomersSearch(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthScope(w, r, scopeReadCustomers) {
+		return
+	}
+	q := r.URL.Query()
+	res := s.fixtures.searchCustomers(
+		r.PathValue("storeId"),
+		q.Get("email"),
+		parseOffset(q.Get("offset")),
+		parseLimit(q.Get("limit")),
+	)
+	writeJSON(w, http.StatusOK, res)
+}
+
+// handleCustomerGet serves GET /api/v3/{storeId}/customers/{id} (scope
+// read_customers): a single customer, or 404 when absent.
+func (s *Server) handleCustomerGet(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthScope(w, r, scopeReadCustomers) {
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "customer not found")
+		return
+	}
+	c, ok := s.fixtures.getCustomer(r.PathValue("storeId"), id)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "customer not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, c)
+}
+
+// handleCustomerUpdate serves PUT /api/v3/{storeId}/customers/{id} (scope
+// update_customers). The body is a partial customer; supplied fields (e.g.
+// acceptMarketing) are merged into the stored record so a later GET reflects the
+// write. It answers with {"updateCount":1}, matching the real API, or 404 when
+// the customer does not exist.
+func (s *Server) handleCustomerUpdate(w http.ResponseWriter, r *http.Request) {
+	if !s.requireAuthScope(w, r, scopeUpdateCustomers) {
+		return
+	}
+	id, err := strconv.ParseInt(r.PathValue("id"), 10, 64)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "customer not found")
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxCustomerBodyBytes))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+	var patch map[string]json.RawMessage
+	if err := json.Unmarshal(body, &patch); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "request body is not a JSON object")
+		return
+	}
+
+	_, ok, err := s.fixtures.patchCustomer(r.PathValue("storeId"), id, patch)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid customer update: "+err.Error())
+		return
+	}
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "customer not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, customers.UpdateResult{UpdateCount: 1})
+}
+
+// parseOffset parses a non-negative offset, defaulting to 0 for an absent or
+// invalid value.
+func parseOffset(raw string) int {
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// parseLimit parses the page size, defaulting to defaultCustomersLimit when
+// absent or invalid and clamping to maxCustomersLimit, matching the real API.
+func parseLimit(raw string) int {
+	if raw == "" {
+		return defaultCustomersLimit
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultCustomersLimit
+	}
+	if n > maxCustomersLimit {
+		return maxCustomersLimit
+	}
+	return n
+}

--- a/mock/internal/server/fixtures.go
+++ b/mock/internal/server/fixtures.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"maps"
 	"net/http"
@@ -343,9 +345,8 @@ func (s *Server) handleCustomerUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxCustomerBodyBytes))
-	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+	body, ok := readFixtureBody(w, r, maxCustomerBodyBytes)
+	if !ok {
 		return
 	}
 	var patch map[string]json.RawMessage
@@ -354,7 +355,7 @@ func (s *Server) handleCustomerUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, ok, err := s.fixtures.patchCustomer(r.PathValue("storeId"), id, patch)
+	_, ok, err = s.fixtures.patchCustomer(r.PathValue("storeId"), id, patch)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid customer update: "+err.Error())
 		return
@@ -364,6 +365,31 @@ func (s *Server) handleCustomerUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, customers.UpdateResult{UpdateCount: 1})
+}
+
+// readFixtureBody reads a fixture-mutation request body under a size limit. It
+// reads one byte past the limit (like the storage routes) so an over-limit body
+// is reported as 413 rather than silently truncated into a different, possibly
+// valid payload; and it rejects a bare JSON null (400), which the decoders would
+// otherwise accept as an empty map/slice/struct and treat as success. It returns
+// the body and whether the caller may proceed; on false it has already written
+// the error response.
+func readFixtureBody(w http.ResponseWriter, r *http.Request, limit int) ([]byte, bool) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, int64(limit)+1))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+		return nil, false
+	}
+	if len(body) > limit {
+		writeJSONError(w, http.StatusRequestEntityTooLarge,
+			fmt.Sprintf("request body exceeds the %d-byte limit", limit))
+		return nil, false
+	}
+	if bytes.Equal(bytes.TrimSpace(body), []byte("null")) {
+		writeJSONError(w, http.StatusBadRequest, "request body must not be null")
+		return nil, false
+	}
+	return body, true
 }
 
 // parseOffset parses a non-negative offset, defaulting to 0 for an absent or

--- a/mock/internal/server/fixtures_control.go
+++ b/mock/internal/server/fixtures_control.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/matthiasbruns/ecwid-go/ecwid/customers"
@@ -38,14 +37,14 @@ func (s *Server) fixtureStoreID(r *http.Request) string {
 func (s *Server) handleFixtureCustomersPut(w http.ResponseWriter, r *http.Request) {
 	storeID := s.fixtureStoreID(r)
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxFixtureBodyBytes))
-	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+	body, ok := readFixtureBody(w, r, maxFixtureBodyBytes)
+	if !ok {
 		return
 	}
 
 	// Try an array first; a single object fails that and falls through to the
-	// object decode below.
+	// object decode below. A null body is already rejected by readFixtureBody, so
+	// a successful array decode here yields a non-nil slice.
 	var many []customers.Customer
 	if err := json.Unmarshal(body, &many); err == nil {
 		ids := make([]int64, 0, len(many))
@@ -70,9 +69,8 @@ func (s *Server) handleFixtureCustomersPut(w http.ResponseWriter, r *http.Reques
 func (s *Server) handleFixtureProfilePut(w http.ResponseWriter, r *http.Request) {
 	storeID := s.fixtureStoreID(r)
 
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxFixtureBodyBytes))
-	if err != nil {
-		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+	body, ok := readFixtureBody(w, r, maxFixtureBodyBytes)
+	if !ok {
 		return
 	}
 	var p profile.Profile

--- a/mock/internal/server/fixtures_control.go
+++ b/mock/internal/server/fixtures_control.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/customers"
+	"github.com/matthiasbruns/ecwid-go/ecwid/profile"
+)
+
+// The fixtures control API lives under the /_mock/ control plane (never under
+// /api/v3/, so it can never collide with a real Ecwid route). It is the
+// programmatic hook an out-of-process consumer — e.g. an integration test suite
+// that boots the mock as a subprocess — uses to install its own fixtures before
+// driving the simulated REST endpoints. Like the webhook control API it is a
+// local dev surface and requires no bearer token.
+
+// maxFixtureBodyBytes bounds a fixtures-control request body.
+const maxFixtureBodyBytes = 1 << 20
+
+// fixtureStoreID resolves which store a fixtures-control request targets: the
+// ?storeId= query value when present, otherwise the mock's configured store. A
+// consumer seeding a single store can omit it; a multi-tenant consumer names the
+// store explicitly.
+func (s *Server) fixtureStoreID(r *http.Request) string {
+	if v := r.URL.Query().Get("storeId"); v != "" {
+		return v
+	}
+	return s.cfg.StoreID
+}
+
+// handleFixtureCustomersPut serves POST /_mock/fixtures/customers: it upserts one
+// customer (a JSON object) or many (a JSON array) into the target store. A
+// customer with no id is assigned one. It replies with {"id":N} for a single
+// customer or {"ids":[...]} for an array, so the caller can address the seeded
+// records afterward.
+func (s *Server) handleFixtureCustomersPut(w http.ResponseWriter, r *http.Request) {
+	storeID := s.fixtureStoreID(r)
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxFixtureBodyBytes))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+
+	// Try an array first; a single object fails that and falls through to the
+	// object decode below.
+	var many []customers.Customer
+	if err := json.Unmarshal(body, &many); err == nil {
+		ids := make([]int64, 0, len(many))
+		for i := range many {
+			ids = append(ids, s.fixtures.putCustomer(storeID, many[i]))
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ids": ids})
+		return
+	}
+
+	var one customers.Customer
+	if err := json.Unmarshal(body, &one); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "body must be a customer object or an array of customers")
+		return
+	}
+	id := s.fixtures.putCustomer(storeID, one)
+	writeJSON(w, http.StatusOK, map[string]any{"id": id})
+}
+
+// handleFixtureProfilePut serves PUT /_mock/fixtures/profile: it installs the
+// store profile for the target store from the request body.
+func (s *Server) handleFixtureProfilePut(w http.ResponseWriter, r *http.Request) {
+	storeID := s.fixtureStoreID(r)
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxFixtureBodyBytes))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "failed to read request body")
+		return
+	}
+	var p profile.Profile
+	if err := json.Unmarshal(body, &p); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "body must be a store profile object")
+		return
+	}
+	s.fixtures.setProfile(storeID, &p)
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}

--- a/mock/internal/server/fixtures_test.go
+++ b/mock/internal/server/fixtures_test.go
@@ -318,6 +318,7 @@ func TestFixtures_CustomerUpdate_Errors(t *testing.T) {
 		{name: "missing customer is 404", id: "999999", body: `{"acceptMarketing":true}`, wantStatus: http.StatusNotFound},
 		{name: "non-numeric id is 404", id: "xyz", body: `{"acceptMarketing":true}`, wantStatus: http.StatusNotFound},
 		{name: "malformed body is 400", id: "1001", body: `not json`, wantStatus: http.StatusBadRequest},
+		{name: "null body is 400", id: "1001", body: `null`, wantStatus: http.StatusBadRequest},
 		{name: "scope denied is 403", id: "1001", scopes: []string{scopeReadCustomers}, body: `{"acceptMarketing":true}`, wantStatus: http.StatusForbidden},
 	}
 
@@ -439,6 +440,37 @@ func TestFixtures_ControlSeed(t *testing.T) {
 			t.Errorf("malformed seed status = %d, want 400", rec.Code)
 		}
 	})
+
+	// A bare JSON null must be rejected on both control endpoints rather than
+	// accepted as an empty slice/struct (which would silently seed nothing or
+	// wipe the profile).
+	t.Run("null seed bodies are 400", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+		for _, tc := range []struct {
+			method, path string
+		}{
+			{http.MethodPost, "/_mock/fixtures/customers"},
+			{http.MethodPut, "/_mock/fixtures/profile"},
+		} {
+			rec := do(srv, httptest.NewRequest(tc.method, tc.path, strings.NewReader("null")))
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("%s %s null body status = %d, want 400", tc.method, tc.path, rec.Code)
+			}
+		}
+	})
+}
+
+// TestFixtures_CustomerUpdate_OverLimit asserts an over-limit update body is
+// rejected with 413 rather than silently truncated (which could turn an invalid
+// body into a smaller valid one).
+func TestFixtures_CustomerUpdate_OverLimit(t *testing.T) {
+	srv := newFixtureServer(nil)
+	// A valid-looking JSON object padded past the byte limit with whitespace.
+	oversized := `{"acceptMarketing":true}` + strings.Repeat(" ", maxCustomerBodyBytes)
+	rec := do(srv, fixtureReq(http.MethodPut, restPath("customers/1001"), strings.NewReader(oversized)))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("over-limit update status = %d, want 413", rec.Code)
+	}
 }
 
 // ── Fixtures are never proxied ───────────────────────────────────────────

--- a/mock/internal/server/fixtures_test.go
+++ b/mock/internal/server/fixtures_test.go
@@ -1,0 +1,499 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/matthiasbruns/ecwid-go/ecwid/customers"
+	"github.com/matthiasbruns/ecwid-go/ecwid/profile"
+	"github.com/matthiasbruns/ecwid-go/mock/internal/config"
+)
+
+// newFixtureServer builds a server with a known access token and store, seeded
+// with the default fixtures, for the simulated REST tests. scopes narrows the
+// granted scopes; nil grants all (the default).
+func newFixtureServer(scopes []string) *Server {
+	return New(config.Config{
+		Port:        0,
+		AccessToken: testToken,
+		StoreID:     testStoreID,
+		Scopes:      scopes,
+	}, discardLogger())
+}
+
+// fixtureReq builds an authorized request against a simulated REST route.
+func fixtureReq(method, target string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	return req
+}
+
+// restPath builds an /api/v3/{storeId}/... path for the test store.
+func restPath(suffix string) string {
+	return "/api/v3/" + testStoreID + "/" + suffix
+}
+
+// ── Profile ──────────────────────────────────────────────────────────────
+
+// TestFixtures_Profile covers GET /profile: the seeded default is returned with
+// the store ID wired through, and the read_store_profile scope is enforced.
+func TestFixtures_Profile(t *testing.T) {
+	t.Run("returns seeded profile with store id", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+		rec := do(srv, fixtureReq(http.MethodGet, restPath("profile"), nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("GET profile status = %d, want 200", rec.Code)
+		}
+		var p profile.Profile
+		if err := json.NewDecoder(rec.Body).Decode(&p); err != nil {
+			t.Fatalf("decode profile: %v", err)
+		}
+		if p.GeneralInfo == nil || p.GeneralInfo.StoreID != 1003 {
+			t.Errorf("profile generalInfo.storeId = %+v, want 1003", p.GeneralInfo)
+		}
+		if p.Settings == nil || p.Settings.StoreName == "" {
+			t.Errorf("profile settings.storeName is empty, want a seeded name")
+		}
+	})
+
+	t.Run("scope denied is 403", func(t *testing.T) {
+		srv := newFixtureServer([]string{scopeReadCustomers}) // profile scope withheld
+		rec := do(srv, fixtureReq(http.MethodGet, restPath("profile"), nil))
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("GET profile without scope status = %d, want 403", rec.Code)
+		}
+		assertErrorBody(t, rec.Body.Bytes(), scopeReadStoreProfile)
+	})
+
+	t.Run("wrong bearer is 401", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+		req := httptest.NewRequest(http.MethodGet, restPath("profile"), http.NoBody)
+		req.Header.Set("Authorization", "Bearer not-the-token")
+		rec := do(srv, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("GET profile wrong bearer status = %d, want 401", rec.Code)
+		}
+	})
+}
+
+// ── Customers: list / paging / email filter ──────────────────────────────
+
+// TestFixtures_CustomersSearch covers GET /customers: the paged envelope, offset
+// and limit windowing, the email filter, and scope enforcement.
+func TestFixtures_CustomersSearch(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		wantStatus int
+		wantTotal  int
+		wantCount  int
+		wantOffset int
+		wantLimit  int
+		wantEmails []string
+	}{
+		{
+			name:       "unpaged returns all in default window",
+			query:      "",
+			wantStatus: http.StatusOK,
+			wantTotal:  3,
+			wantCount:  3,
+			wantOffset: 0,
+			wantLimit:  defaultCustomersLimit,
+			wantEmails: []string{"ada@example.com", "grace@example.com", "alan@example.com"},
+		},
+		{
+			name:       "first page of two",
+			query:      "?offset=0&limit=2",
+			wantStatus: http.StatusOK,
+			wantTotal:  3,
+			wantCount:  2,
+			wantOffset: 0,
+			wantLimit:  2,
+			wantEmails: []string{"ada@example.com", "grace@example.com"},
+		},
+		{
+			name:       "second page carries the remainder",
+			query:      "?offset=2&limit=2",
+			wantStatus: http.StatusOK,
+			wantTotal:  3,
+			wantCount:  1,
+			wantOffset: 2,
+			wantLimit:  2,
+			wantEmails: []string{"alan@example.com"},
+		},
+		{
+			name:       "offset past the end is an empty page",
+			query:      "?offset=99&limit=2",
+			wantStatus: http.StatusOK,
+			wantTotal:  3,
+			wantCount:  0,
+			wantOffset: 99,
+			wantLimit:  2,
+			wantEmails: []string{},
+		},
+		{
+			name:       "email filter finds the one match",
+			query:      "?email=grace@example.com",
+			wantStatus: http.StatusOK,
+			wantTotal:  1,
+			wantCount:  1,
+			wantOffset: 0,
+			wantLimit:  defaultCustomersLimit,
+			wantEmails: []string{"grace@example.com"},
+		},
+		{
+			name:       "email filter is case-insensitive",
+			query:      "?email=ADA@example.com",
+			wantStatus: http.StatusOK,
+			wantTotal:  1,
+			wantCount:  1,
+			wantOffset: 0,
+			wantLimit:  defaultCustomersLimit,
+			wantEmails: []string{"ada@example.com"},
+		},
+		{
+			name:       "email filter with no match is empty",
+			query:      "?email=nobody@example.com",
+			wantStatus: http.StatusOK,
+			wantTotal:  0,
+			wantCount:  0,
+			wantOffset: 0,
+			wantLimit:  defaultCustomersLimit,
+			wantEmails: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newFixtureServer(nil)
+			rec := do(srv, fixtureReq(http.MethodGet, restPath("customers")+tc.query, nil))
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			var res customers.SearchResult
+			if err := json.NewDecoder(rec.Body).Decode(&res); err != nil {
+				t.Fatalf("decode search result: %v", err)
+			}
+			if res.Total != tc.wantTotal {
+				t.Errorf("total = %d, want %d", res.Total, tc.wantTotal)
+			}
+			if res.Count != tc.wantCount {
+				t.Errorf("count = %d, want %d", res.Count, tc.wantCount)
+			}
+			if res.Offset != tc.wantOffset {
+				t.Errorf("offset = %d, want %d", res.Offset, tc.wantOffset)
+			}
+			if res.Limit != tc.wantLimit {
+				t.Errorf("limit = %d, want %d", res.Limit, tc.wantLimit)
+			}
+			if res.Count != len(res.Items) {
+				t.Errorf("count = %d but items has %d entries", res.Count, len(res.Items))
+			}
+			gotEmails := make([]string, len(res.Items))
+			for i, c := range res.Items {
+				gotEmails[i] = c.Email
+			}
+			if strings.Join(gotEmails, ",") != strings.Join(tc.wantEmails, ",") {
+				t.Errorf("emails = %v, want %v", gotEmails, tc.wantEmails)
+			}
+		})
+	}
+
+	t.Run("scope denied is 403", func(t *testing.T) {
+		srv := newFixtureServer([]string{scopeReadStoreProfile}) // customers scope withheld
+		rec := do(srv, fixtureReq(http.MethodGet, restPath("customers"), nil))
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("status = %d, want 403", rec.Code)
+		}
+		assertErrorBody(t, rec.Body.Bytes(), scopeReadCustomers)
+	})
+}
+
+// TestFixtures_ItemsEncodesAsArray asserts an empty page serializes as [] rather
+// than null, matching the real API (a nil items slice would break typed clients
+// that range over it).
+func TestFixtures_ItemsEncodesAsArray(t *testing.T) {
+	srv := newFixtureServer(nil)
+	rec := do(srv, fixtureReq(http.MethodGet, restPath("customers")+"?email=nobody@example.com", nil))
+	if !strings.Contains(rec.Body.String(), `"items":[]`) {
+		t.Errorf("empty page body = %s, want items:[]", rec.Body.String())
+	}
+}
+
+// ── Customers: get by id ─────────────────────────────────────────────────
+
+// TestFixtures_CustomerGet covers GET /customers/{id}: a seeded customer, a
+// missing id, a non-numeric id, and scope enforcement.
+func TestFixtures_CustomerGet(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		scopes     []string
+		wantStatus int
+		wantEmail  string
+	}{
+		{name: "existing customer", id: "1001", wantStatus: http.StatusOK, wantEmail: "ada@example.com"},
+		{name: "missing customer is 404", id: "424242", wantStatus: http.StatusNotFound},
+		{name: "non-numeric id is 404", id: "abc", wantStatus: http.StatusNotFound},
+		{name: "scope denied is 403", id: "1001", scopes: []string{scopeReadStoreProfile}, wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newFixtureServer(tc.scopes)
+			rec := do(srv, fixtureReq(http.MethodGet, restPath("customers/"+tc.id), nil))
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if tc.wantStatus != http.StatusOK {
+				return
+			}
+			var c customers.Customer
+			if err := json.NewDecoder(rec.Body).Decode(&c); err != nil {
+				t.Fatalf("decode customer: %v", err)
+			}
+			if c.Email != tc.wantEmail {
+				t.Errorf("email = %q, want %q", c.Email, tc.wantEmail)
+			}
+		})
+	}
+}
+
+// ── Customers: update marketing consent (read-after-write) ───────────────
+
+// TestFixtures_CustomerUpdate_ReadAfterWrite proves the PUT is reflected in
+// subsequent GETs: flipping acceptMarketing true persists, other fields are
+// preserved, and the update requires the update_customers scope.
+func TestFixtures_CustomerUpdate_ReadAfterWrite(t *testing.T) {
+	srv := newFixtureServer(nil)
+
+	// Grace starts with acceptMarketing=false.
+	before := getFixtureCustomer(t, srv, 1002)
+	if before.AcceptMarketing == nil || *before.AcceptMarketing {
+		t.Fatalf("seed precondition: customer 1002 acceptMarketing = %v, want false", before.AcceptMarketing)
+	}
+
+	// Flip it to true via PUT (only acceptMarketing in the body, as SetCustomerMarketing sends).
+	rec := do(srv, fixtureReq(http.MethodPut, restPath("customers/1002"), strings.NewReader(`{"acceptMarketing":true}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want 200", rec.Code)
+	}
+	var upd customers.UpdateResult
+	if err := json.NewDecoder(rec.Body).Decode(&upd); err != nil {
+		t.Fatalf("decode update result: %v", err)
+	}
+	if upd.UpdateCount != 1 {
+		t.Errorf("updateCount = %d, want 1", upd.UpdateCount)
+	}
+
+	// The next GET must reflect the write, with untouched fields preserved.
+	after := getFixtureCustomer(t, srv, 1002)
+	if after.AcceptMarketing == nil || !*after.AcceptMarketing {
+		t.Errorf("after PUT acceptMarketing = %v, want true (read-after-write)", after.AcceptMarketing)
+	}
+	if after.Email != before.Email || after.Name != before.Name {
+		t.Errorf("PUT clobbered untouched fields: name/email = %q/%q, want %q/%q",
+			after.Name, after.Email, before.Name, before.Email)
+	}
+	if after.ID != 1002 {
+		t.Errorf("PUT changed the id to %d, want it fixed at 1002", after.ID)
+	}
+}
+
+// TestFixtures_CustomerUpdate_Errors covers the unhappy PUT paths: missing
+// customer, malformed body, and scope enforcement.
+func TestFixtures_CustomerUpdate_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		scopes     []string
+		body       string
+		wantStatus int
+	}{
+		{name: "missing customer is 404", id: "999999", body: `{"acceptMarketing":true}`, wantStatus: http.StatusNotFound},
+		{name: "non-numeric id is 404", id: "xyz", body: `{"acceptMarketing":true}`, wantStatus: http.StatusNotFound},
+		{name: "malformed body is 400", id: "1001", body: `not json`, wantStatus: http.StatusBadRequest},
+		{name: "scope denied is 403", id: "1001", scopes: []string{scopeReadCustomers}, body: `{"acceptMarketing":true}`, wantStatus: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newFixtureServer(tc.scopes)
+			rec := do(srv, fixtureReq(http.MethodPut, restPath("customers/"+tc.id), strings.NewReader(tc.body)))
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if tc.wantStatus == http.StatusForbidden {
+				assertErrorBody(t, rec.Body.Bytes(), scopeUpdateCustomers)
+			}
+		})
+	}
+}
+
+// ── Fixtures control API ─────────────────────────────────────────────────
+
+// TestFixtures_ControlSeed covers the /_mock/fixtures control API: seeding a new
+// customer with a known email is then findable via the simulated REST endpoints,
+// and a replacement profile is served back.
+func TestFixtures_ControlSeed(t *testing.T) {
+	t.Run("seed a customer then find it by email", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+
+		body := `{"name":"Katherine Johnson","email":"katherine@example.com","acceptMarketing":false}`
+		rec := do(srv, httptest.NewRequest(http.MethodPost, "/_mock/fixtures/customers", strings.NewReader(body)))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("seed customer status = %d, want 200", rec.Code)
+		}
+		var seeded struct {
+			ID int64 `json:"id"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&seeded); err != nil {
+			t.Fatalf("decode seed response: %v", err)
+		}
+		if seeded.ID == 0 {
+			t.Fatalf("seed response id = 0, want an assigned id")
+		}
+
+		// The simulated REST email filter now finds it.
+		find := do(srv, fixtureReq(http.MethodGet, restPath("customers")+"?email=katherine@example.com", nil))
+		var res customers.SearchResult
+		if err := json.NewDecoder(find.Body).Decode(&res); err != nil {
+			t.Fatalf("decode search: %v", err)
+		}
+		if res.Total != 1 || len(res.Items) != 1 || res.Items[0].ID != seeded.ID {
+			t.Errorf("find by email = %+v, want the seeded customer id %d", res, seeded.ID)
+		}
+	})
+
+	t.Run("seed an array of customers", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+		body := `[{"email":"a@x.com"},{"email":"b@x.com"}]`
+		rec := do(srv, httptest.NewRequest(http.MethodPost, "/_mock/fixtures/customers", strings.NewReader(body)))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("seed array status = %d, want 200", rec.Code)
+		}
+		var out struct {
+			IDs []int64 `json:"ids"`
+		}
+		if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+			t.Fatalf("decode seed response: %v", err)
+		}
+		if len(out.IDs) != 2 {
+			t.Errorf("seeded ids = %v, want 2 ids", out.IDs)
+		}
+	})
+
+	t.Run("replace the profile", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+		body := `{"settings":{"storeName":"Reseeded Store"}}`
+		rec := do(srv, httptest.NewRequest(http.MethodPut, "/_mock/fixtures/profile", strings.NewReader(body)))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("seed profile status = %d, want 200", rec.Code)
+		}
+		get := do(srv, fixtureReq(http.MethodGet, restPath("profile"), nil))
+		var p profile.Profile
+		if err := json.NewDecoder(get.Body).Decode(&p); err != nil {
+			t.Fatalf("decode profile: %v", err)
+		}
+		if p.Settings == nil || p.Settings.StoreName != "Reseeded Store" {
+			t.Errorf("profile storeName = %+v, want Reseeded Store", p.Settings)
+		}
+	})
+
+	t.Run("seed targets a named store via storeId", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+		body := `{"email":"tenant@example.com"}`
+		rec := do(srv, httptest.NewRequest(http.MethodPost, "/_mock/fixtures/customers?storeId=2222", strings.NewReader(body)))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("seed status = %d, want 200", rec.Code)
+		}
+		// It lands under store 2222, not the default store.
+		other := do(srv, fixtureReq(http.MethodGet, "/api/v3/2222/customers?email=tenant@example.com", nil))
+		var res customers.SearchResult
+		if err := json.NewDecoder(other.Body).Decode(&res); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if res.Total != 1 {
+			t.Errorf("store 2222 total = %d, want 1", res.Total)
+		}
+		// The default store is unaffected.
+		def := do(srv, fixtureReq(http.MethodGet, restPath("customers")+"?email=tenant@example.com", nil))
+		var defRes customers.SearchResult
+		if err := json.NewDecoder(def.Body).Decode(&defRes); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if defRes.Total != 0 {
+			t.Errorf("default store leaked the tenant customer: total = %d, want 0", defRes.Total)
+		}
+	})
+
+	t.Run("malformed seed body is 400", func(t *testing.T) {
+		srv := newFixtureServer(nil)
+		rec := do(srv, httptest.NewRequest(http.MethodPost, "/_mock/fixtures/customers", strings.NewReader("not json")))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("malformed seed status = %d, want 400", rec.Code)
+		}
+	})
+}
+
+// ── Fixtures are never proxied ───────────────────────────────────────────
+
+// TestFixtures_NotProxied asserts the simulated endpoints are served locally
+// even with proxying enabled — a real store is never contacted for them.
+func TestFixtures_NotProxied(t *testing.T) {
+	srv := New(config.Config{
+		Port:          0,
+		AccessToken:   testToken,
+		StoreID:       testStoreID,
+		ProxyStore:    "999",
+		ProxyToken:    "real-token",
+		ProxyReadonly: false,
+	}, discardLogger())
+	// Point the proxy at a URL that must never be reached.
+	srv.upstreamBase = "http://proxy.invalid"
+
+	for _, suffix := range []string{"profile", "customers", "customers/1001"} {
+		rec := do(srv, fixtureReq(http.MethodGet, restPath(suffix), nil))
+		if rec.Code != http.StatusOK {
+			t.Errorf("GET %s status = %d, want 200 (served locally, not proxied)", suffix, rec.Code)
+		}
+	}
+}
+
+// getFixtureCustomer GETs a customer by id through the REST handler and decodes
+// it, failing if the status is not 200.
+func getFixtureCustomer(t *testing.T, srv *Server, id int64) customers.Customer {
+	t.Helper()
+	rec := do(srv, fixtureReq(http.MethodGet, restPath("customers/"+strconv.FormatInt(id, 10)), nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET customer %d status = %d, want 200", id, rec.Code)
+	}
+	var c customers.Customer
+	if err := json.NewDecoder(rec.Body).Decode(&c); err != nil {
+		t.Fatalf("decode customer: %v", err)
+	}
+	return c
+}
+
+// assertErrorBody asserts the response body is the Ecwid error shape
+// {"errorMessage":...} and that the message names the expected scope.
+func assertErrorBody(t *testing.T, body []byte, wantScope string) {
+	t.Helper()
+	var e struct {
+		ErrorMessage string `json:"errorMessage"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil {
+		t.Fatalf("error body is not JSON: %v (%s)", err, body)
+	}
+	if e.ErrorMessage == "" {
+		t.Errorf("error body has no errorMessage: %s", body)
+	}
+	if wantScope != "" && !strings.Contains(e.ErrorMessage, wantScope) {
+		t.Errorf("error message %q does not name the required scope %q", e.ErrorMessage, wantScope)
+	}
+}

--- a/mock/internal/server/server.go
+++ b/mock/internal/server/server.go
@@ -46,12 +46,13 @@ const shutdownTimeout = 10 * time.Second
 
 // Server wraps the HTTP server and its configuration.
 type Server struct {
-	cfg     config.Config
-	log     *slog.Logger
-	mux     *http.ServeMux
-	http    *http.Server
-	store   *appStorage
-	trigger *webhook.Trigger
+	cfg      config.Config
+	log      *slog.Logger
+	mux      *http.ServeMux
+	http     *http.Server
+	store    *appStorage
+	fixtures *fixtureStore
+	trigger  *webhook.Trigger
 
 	// upstreamBase is the scheme+host proxied requests are forwarded to. It
 	// defaults to defaultUpstreamBase and is overridden by tests to point at an
@@ -74,10 +75,11 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 	addr := net.JoinHostPort("", strconv.Itoa(cfg.Port))
 
 	s := &Server{
-		cfg:   cfg,
-		log:   log,
-		mux:   mux,
-		store: newAppStorage(),
+		cfg:      cfg,
+		log:      log,
+		mux:      mux,
+		store:    newAppStorage(),
+		fixtures: newFixtureStore(),
 		trigger: webhook.NewTrigger(webhook.Config{
 			ClientSecret: cfg.ClientSecret,
 			StoreID:      parseStoreID(cfg.StoreID, log),
@@ -86,6 +88,10 @@ func New(cfg config.Config, log *slog.Logger) *Server {
 		upstreamBase: defaultUpstreamBase,
 		proxyClient:  &http.Client{Timeout: proxyTimeout, Transport: newProxyTransport()},
 	}
+
+	// Seed the configured store so the simulated customer/profile endpoints
+	// answer the happy path with no seeding required by the consumer.
+	seedDefaults(s.fixtures, cfg.StoreID)
 
 	s.routes()
 
@@ -120,6 +126,18 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("PUT /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
 	s.mux.HandleFunc("POST /api/v3/{storeId}/storage/{key}", s.handleStoragePut)
 	s.mux.HandleFunc("DELETE /api/v3/{storeId}/storage/{key}", s.handleStorageDelete)
+
+	// Simulated Ecwid REST: store profile and customers, served from in-memory
+	// fixtures (the default — no real store or proxy needed). These specific
+	// patterns are preferred by ServeMux over the proxy/501 catch-all below.
+	s.mux.HandleFunc("GET /api/v3/{storeId}/profile", s.handleProfileGet)
+	s.mux.HandleFunc("GET /api/v3/{storeId}/customers", s.handleCustomersSearch)
+	s.mux.HandleFunc("GET /api/v3/{storeId}/customers/{id}", s.handleCustomerGet)
+	s.mux.HandleFunc("PUT /api/v3/{storeId}/customers/{id}", s.handleCustomerUpdate)
+
+	// Control plane: seed/override the customer and profile fixtures.
+	s.mux.HandleFunc("POST /_mock/fixtures/customers", s.handleFixtureCustomersPut)
+	s.mux.HandleFunc("PUT /_mock/fixtures/profile", s.handleFixtureProfilePut)
 
 	// Simulated Ecwid REST namespace. This catch-all backstops every REST route
 	// the mock does not implement locally: it proxies to a real store when


### PR DESCRIPTION
## Summary

The `mock` module (`ecwid-mock`) previously simulated only the app-storage endpoints and **proxied everything else to a real store**. This closes that gap for the endpoints a consuming app needs, so it can be exercised **fully hermetically** — no real store, no proxy.

Unblocks a parallel `ecwid-brevo` task that wires this mock into its E2E suite. Fixtures are kept generic to the Ecwid API (nothing ecwid-brevo-specific here).

## New simulated endpoints (fixtures are the default; never proxied)

| Endpoint | Scope | Notes |
|---|---|---|
| `GET /api/v3/{storeId}/profile` | `read_store_profile` | store profile |
| `GET /api/v3/{storeId}/customers` | `read_customers` | paged `items/count/total/offset/limit`; `?offset`/`?limit` window, `?email=` case-insensitive filter (find-by-email) |
| `GET /api/v3/{storeId}/customers/{id}` | `read_customers` | single customer or 404 |
| `PUT /api/v3/{storeId}/customers/{id}` | `update_customers` | field-merge (e.g. `acceptMarketing`), `{"updateCount":1}`, reflected in later GETs (read-after-write) |

## Key points

- **Shapes match the typed client by construction** — fixtures are built from this repo's own `ecwid/customers` and `ecwid/profile` structs, so the mock and the SDK cannot drift.
- **Scope gates** — `--scopes` / `ECWID_MOCK_SCOPES` (empty = all granted, the default). A withheld scope returns Ecwid's `403 {"errorMessage":...}` shape; a bad/missing bearer → 401, matching the storage routes.
- **Seeding** — the configured store is seeded at startup (profile + 3 customers, one with `acceptMarketing:false` ready to flip). A control API lets an out-of-process consumer install its own: `POST /_mock/fixtures/customers` (object or array, `?storeId=` for multi-tenant) and `PUT /_mock/fixtures/profile`.
- **Always local, never proxied** — even with proxying enabled.

## Tests

Table-driven, hermetic, `-race` green: each endpoint incl. paging, email filter, case-insensitivity, read-after-write on `acceptMarketing`, scope-denied (403), 401, 404, empty page encodes as `items:[]`, never-proxied, and control-API seeding. Plus config tests for `HasScope` / `parseScopes` / `--scopes`. `golangci-lint` and `go vet` clean; `go mod tidy` is a no-op.

## Release

No new `ecwid` symbols are added (reuses existing public `ecwid/customers` / `ecwid/profile` types), so no `ecwid` changes are required. Per the repo's `release` workflow, the next dispatch tags `config`/`ecwid`/`mock` together and pins `mock → ecwid@<version>`; no tags are cut in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulated store profile and customer REST endpoints with seeded fixture data.
  * Added customer search, retrieval, and updates with pagination and filtering.
  * Added local controls for seeding or replacing customer and profile fixtures.
  * Added the `--scopes` option for testing access permissions with selected scopes.

* **Documentation**
  * Clarified fixture behavior, scope enforcement, proxy handling, and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->